### PR TITLE
better skip behaviour

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -199,17 +199,12 @@ export default function graphql(
 
         this.type = operation.type;
 
-        if (this.shouldSkip(props)) return;
         this.setInitialProps();
       }
 
       componentDidMount() {
         this.hasMounted = true;
         if (this.type === DocumentType.Mutation) return;
-
-        if (!this.shouldSkip(this.props)) {
-          this.subscribeToQuery();
-        }
       }
 
       componentWillReceiveProps(nextProps) {
@@ -220,6 +215,7 @@ export default function graphql(
         if (this.type === DocumentType.Mutation) {
           return;
         };
+
         if (this.type === DocumentType.Subscription
           && operationOptions.shouldResubscribe
           && operationOptions.shouldResubscribe(this.props, nextProps)) {
@@ -227,13 +223,6 @@ export default function graphql(
           delete this.queryObservable;
           this.updateQuery(nextProps);
           this.subscribeToQuery();
-          return;
-        }
-        if (this.shouldSkip(nextProps)) {
-          if (!this.shouldSkip(this.props)) {
-            // if this has changed, we better unsubscribe
-            this.unsubscribeFromQuery();
-          }
           return;
         }
 
@@ -259,6 +248,10 @@ export default function graphql(
           newOpts.variables = assign({}, opts.variables, newOpts.variables);
         }
         if (newOpts) opts = assign({}, opts, newOpts);
+
+        if (operation.type !== DocumentType.Mutation) {
+          opts = assign({}, opts, { noFetch: (opts as QueryOptions).noFetch || !!this.shouldSkip(props) });
+        }
 
         if (opts.variables || !operation.variables.length) return opts;
 
@@ -353,7 +346,6 @@ export default function graphql(
 
       // For server-side rendering (see server.ts)
       fetchData(): Promise<ApolloQueryResult<any>> | boolean {
-        if (this.shouldSkip()) return false;
         if (
           operation.type === DocumentType.Mutation || operation.type === DocumentType.Subscription
         ) return false;
@@ -463,8 +455,8 @@ export default function graphql(
         } else {
           // fetch the current result (if any) from the store
           const currentResult = this.queryObservable.currentResult();
-          const { loading, error, networkStatus } = currentResult;
-          assign(data, { loading, error, networkStatus });
+          const { loading, error, networkStatus, partial } = currentResult;
+          assign(data, { loading, error, networkStatus, partial });
 
           if (loading) {
             // while loading, we should use any previous data we have
@@ -478,10 +470,6 @@ export default function graphql(
       }
 
       render() {
-        if (this.shouldSkip()) {
-          return createElement(WrappedComponent, this.props);
-        }
-
         const { shouldRerender, renderedElement, props } = this;
         this.shouldRerender = false;
 


### PR DESCRIPTION
Hi,

I am proposing a better behaviour for the skip feature.

# Problems of the current implementation

- if skip is true, the component is (re)rendered without the data and consequently does not get update of the data even if it's updated in the query cache because of some other action that happens in the app.
- When skip switches to false, it will run the query again against the server even if forceFetch is not true and that the data is already available
- Missing some infos about knowing if this is in loading state because it's refreshing or because the result are not full (`partial` part of the pr, related to https://github.com/apollostack/apollo-client/pull/1097)

# Proposed solution

Instead of unsubscribing, resubscribing, i suggest to keep it simple and only switch noFetch to true/false depending of the skip value. and keep being subscribed.
**skip is to be seen as a way to prevent request to be run against the server when conditions are not met. But if the component defines it's underlying query, it means he wants the data if it's available!!**
this is enabled by https://github.com/apollostack/apollo-client/pull/1067.
switching noFetch from true to false will only run the request against the server if the result if not fully in cache yet or if forceFetch options is set to yes. Which is what we want

## conclusion

If you are ok with that i can finalize the PR

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
