### PR TITLE
Fix failing tests on `master`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "editor.rulers": [100],
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
-  "editor.wrappingColumn": 100,
+  "editor.wrappingColumn": -1,
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "deploy": "npm run compile && npm test && npm publish",
     "test": "jest",
-    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "test-watch": "jest --watch",
     "posttest": "npm run lint",
     "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=15",
     "compile": "tsc",
@@ -40,7 +40,7 @@
     "preset": "jest-react-native",
     "testEnvironment": "jsdom",
     "transform": {
-      ".*": "preprocessor.js"
+      ".*": "<rootDir>/preprocessor.js"
     },
     "moduleFileExtensions": [
       "ts",
@@ -98,13 +98,13 @@
     "enzyme": "^2.2.0",
     "enzyme-to-json": "^1.1.5",
     "flow-bin": "^0.32.0",
-    "graphql": "^0.5.0",
+    "graphql": "^0.9.1",
     "graphql-tag": "^0.1.7",
     "gzip-size": "^3.0.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",
-    "jest": "^16.1.0-alpha.691b0e22",
-    "jest-react-native": "^16.1.0-alpha.691b0e22",
+    "jest": "^18.1.0",
+    "jest-react-native": "^18.0.0",
     "jsdom": "^8.3.1",
     "lodash": "^4.16.6",
     "minimist": "^1.2.0",

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -66,8 +66,8 @@ export interface GraphQLDataProps {
   variables: {
     [variable: string]: any;
   };
-  fetchMore: (fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions) => Promise<ApolloQueryResult>;
-  refetch: (variables?: any) => Promise<ApolloQueryResult>;
+  fetchMore: (fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions) => Promise<ApolloQueryResult<any>>;
+  refetch: (variables?: any) => Promise<ApolloQueryResult<any>>;
   startPolling: (pollInterval: number) => void;
   stopPolling: () => void;
   subscribeToMore: (options: SubscribeToMoreOptions) => () => void;

--- a/test/react-web/client/ApolloProvider.test.tsx
+++ b/test/react-web/client/ApolloProvider.test.tsx
@@ -44,6 +44,8 @@ describe('<ApolloProvider /> Component', () => {
   });
 
   it('should require a client', () => {
+    const originalConsoleError = console.error;
+    console.error = () => { /* noop */ };
     expect(() => {
       shallow(
         <ApolloProvider client={undefined}>
@@ -54,6 +56,7 @@ describe('<ApolloProvider /> Component', () => {
       'ApolloClient was not passed a client instance. Make ' +
       'sure you pass in your client via the "client" prop.'
     );
+    console.error = originalConsoleError;
   });
 
   it('should not require a store', () => {
@@ -67,11 +70,14 @@ describe('<ApolloProvider /> Component', () => {
   });
 
   it('should throw if rendered without a child component', () => {
+    const originalConsoleError = console.error;
+    console.error = () => { /* noop */ };
     expect(() => {
       shallow(
         <ApolloProvider store={store} client={client}/>
       );
     }).toThrowError(Error);
+    console.error = originalConsoleError;
   });
 
   it('should add the client to the child context', () => {


### PR DESCRIPTION
This PR will fix the failing tests on `master`, and mute the warnings Jest emit.

The reason tests were failing was because Parse finally went offline! So the old GraphQL SWAPI API we hit in the tests (http://graphql-swapi.parseapp.com/) is no longer reachable. The new SWAPI is hosted on https://graphql.org/swapi-graphql, but now the [schema](http://graphql.org/swapi-graphql/schema.js) runs entirely on the client and not the server. This means there was no URL to point to.

It’s probably not a good idea that we were sending a network request to someone else’s server in our tests anyway, so this PR refactors the test in question to use a local schema.

This PR also hides expected errors from `PropTypes` in tests and upgrades Jest to fix some errors that were being logged.