### PR TITLE
Provide data prop even when skipping

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- Also provide props when skipping, so destructuring props is easy [PR #461](https://github.com/apollographql/react-apollo/pull/461)
 
 ### 0.10.1
 - Fix wrong invariant sanity checks for GraphQL document [PR #457](https://github.com/apollostack/react-apollo/issues/457)

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -477,6 +477,9 @@ export default function graphql(
       }
 
       dataForChild() {
+        if (this.shouldSkip()) {
+          return {skipped: true};
+        }
         if (this.type === DocumentType.Mutation) {
           return (mutationOpts: MutationOptions) => {
             const opts = this.calculateOptions(this.props, mutationOpts);
@@ -516,10 +519,6 @@ export default function graphql(
       }
 
       render() {
-        if (this.shouldSkip()) {
-          return createElement(WrappedComponent, this.props);
-        }
-
         const { shouldRerender, renderedElement, props } = this;
         this.shouldRerender = false;
 

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -249,8 +249,8 @@ describe('SSR', () => {
       );
       const apolloClient = new ApolloClient({ networkInterface, addTypename: false });
 
-      const WrappedElement = graphql(query, { options: { skip: true }})(({ data }) => (
-        <div>{data ? 'loading' : 'skipped'}</div>
+      const WrappedElement = graphql(query, { options: { skip: true }})(({ data: {skipped} }) => (
+        <div>{skipped ? 'skipped': 'dang'}</div>
       ));
 
       const app = (<ApolloProvider client={apolloClient}><WrappedElement /></ApolloProvider>);
@@ -272,8 +272,8 @@ describe('SSR', () => {
       );
       const apolloClient = new ApolloClient({ networkInterface, addTypename: false });
 
-      const WrappedElement = graphql(query, { skip: true })(({ data }) => (
-        <div>{!data ? 'skipped' : 'dang'}</div>
+      const WrappedElement = graphql(query, { skip: true })(({ data: {skipped} }) => (
+        <div>{skipped ? 'skipped' : 'dang'}</div>
       ));
 
       const app = (<ApolloProvider client={apolloClient}><WrappedElement /></ApolloProvider>);


### PR DESCRIPTION
Fixes #456 
I suppose this is a breaking API change, since it runs `props` at times when before it wouldn't.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
