### PR TITLE
Add recycling for `ObservableQuery`s

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- Fix `updateQueries` not running for queries attached to unmounted components. [PR #462](https://github.com/apollographql/react-apollo/pull/462)
 
 ### 0.10.1
 - Fix wrong invariant sanity checks for GraphQL document [PR #457](https://github.com/apollostack/react-apollo/issues/457)

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -576,12 +576,17 @@ export default function graphql(
  * An observable query recycler stores some observable queries that are no
  * longer in use, but that we may someday use again.
  *
- * Recycling observable queries avoids a few nasty bugs that may be hit when
- * using the `react-apollo` API. Namely not updating queries when a component
- * unmounts, and calling reducers/`updateQueries` more times then is necessary
- * for old observable queries.
+ * Recycling observable queries avoids a few unexpected functionalities that
+ * may be hit when using the `react-apollo` API. Namely not updating queries
+ * when a component unmounts, and calling reducers/`updateQueries` more times
+ * then is necessary for old observable queries.
  *
  * We assume that the GraphQL document for every `ObservableQuery` is the same.
+ *
+ * For more context on why this was added and links to the issues recycling
+ * `ObservableQuery`s fixes see issue [#462][1].
+ *
+ * [1]: https://github.com/apollographql/react-apollo/pull/462
  */
 class ObservableQueryRecycler {
   /**

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -191,6 +191,14 @@ export default function graphql(
 
     const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
 
+    // A recycler that we can use to recycle old observable queries to keep
+    // them hot between component unmounts and remounts.
+    //
+    // Note that the existence of this recycler could potentially cause memory
+    // leaks if many components are being created and unmounted in parallel.
+    // However, this is an unlikely scenario.
+    const recycler = new ObservableQueryRecycler();
+
     class GraphQL extends Component<any, any> {
       static displayName = graphQLDisplayName;
       static WrappedComponent = WrappedComponent;
@@ -210,7 +218,8 @@ export default function graphql(
       private type: DocumentType;
 
       // request / action storage. Note that we delete querySubscription if we
-      // unsubscribe but never delete queryObservable once it is created.
+      // unsubscribe but never delete queryObservable once it is created. We
+      // only delete queryObservable when we unmount the component.
       private queryObservable: ObservableQuery<any> | any;
       private querySubscription: Subscription;
       private previousData: any = {};
@@ -284,7 +293,17 @@ export default function graphql(
       }
 
       componentWillUnmount() {
-        if (this.type === DocumentType.Query) this.unsubscribeFromQuery();
+        if (this.type === DocumentType.Query) {
+          // Recycle the query observable if there ever was one.
+          if (this.queryObservable) {
+            recycler.recycle(this.queryObservable);
+            delete this.queryObservable;
+          }
+
+          // Unsubscribe from our query subscription.
+          this.unsubscribeFromQuery();
+        }
+
         if (this.type === DocumentType.Subscription) this.unsubscribeFromQuery();
 
         this.hasMounted = false;
@@ -353,14 +372,23 @@ export default function graphql(
             query: document,
           }, opts));
         } else {
-          this.queryObservable = this.client.watchQuery(assign({
-            query: document,
-            metadata: {
-              reactComponent: {
-                displayName: graphQLDisplayName,
+          // Try to reuse an `ObservableQuery` instance from our recycler. If
+          // we get null then there is no instance to reuse and we should
+          // create a new `ObservableQuery`. Otherwise we will use our old one.
+          const queryObservable = recycler.reuse(opts);
+
+          if (queryObservable === null) {
+            this.queryObservable = this.client.watchQuery(assign({
+              query: document,
+              metadata: {
+                reactComponent: {
+                  displayName: graphQLDisplayName,
+                },
               },
-            },
-          }, opts));
+            }, opts));
+          } else {
+            this.queryObservable = queryObservable;
+          }
         }
       }
 
@@ -543,3 +571,74 @@ export default function graphql(
 
   return wrapWithApolloComponent;
 };
+
+/**
+ * An observable query recycler stores some observable queries that are no
+ * longer in use, but that we may someday use again.
+ *
+ * Recycling observable queries avoids a few nasty bugs that may be hit when
+ * using the `react-apollo` API. Namely not updating queries when a component
+ * unmounts, and calling reducers/`updateQueries` more times then is necessary
+ * for old observable queries.
+ *
+ * We assume that the GraphQL document for every `ObservableQuery` is the same.
+ */
+class ObservableQueryRecycler {
+  /**
+   * The internal store for our observable queries and temporary subscriptions.
+   */
+  private observableQueries: Array<{
+    observableQuery: ObservableQuery<any>,
+    subscription: Subscription,
+  }> = [];
+
+  /**
+   * Recycles an observable query that the recycler is finished with. It is
+   * stored in this class so that it may be used later on.
+   *
+   * A subscription is made to the observable query so that it continues to
+   * live even though the updates are noops.
+   *
+   * By recycling an observable query we keep the results fresh so that when it
+   * gets reused all of the mutations that have happened since recycle and
+   * reuse have been applied.
+   */
+  public recycle (observableQuery: ObservableQuery<any>): void {
+    // Stop the query from polling when we recycle. Polling may resume when we
+    // reuse it and call `setOptions`.
+    observableQuery.stopPolling();
+
+    this.observableQueries.push({
+      observableQuery,
+      subscription: observableQuery.subscribe({}),
+    });
+  }
+
+  /**
+   * Reuses an observable query that was recycled earlier on in this class’s
+   * lifecycle. This observable was kept fresh by our recycler with a
+   * subscription that will be unsubscribed from before returning the
+   * observable query.
+   *
+   * All mutations that occured between the time of recycling and the time of
+   * reusing have been applied.
+   */
+  public reuse (options: QueryOptions): ObservableQuery<any> {
+    if (this.observableQueries.length <= 0) {
+      return null;
+    }
+    const { observableQuery, subscription } = this.observableQueries.pop();
+    subscription.unsubscribe();
+
+    // When we reuse an `ObservableQuery` then the document and component
+    // GraphQL display name should be the same. Only the options may be
+    // different.
+    //
+    // Therefore we need to set the new options.
+    //
+    // If this observable query used to poll then polling will be restarted.
+    observableQuery.setOptions(options);
+
+    return observableQuery;
+  }
+}

--- a/test/react-web/client/graphql/mutations.test.tsx
+++ b/test/react-web/client/graphql/mutations.test.tsx
@@ -394,4 +394,218 @@ describe('mutations', () => {
     renderer.create(<ApolloProvider client={client}><Container id={'123'} /></ApolloProvider>);
   });
 
+  it('will run `updateQueries` for a previously mounted component', () => new Promise((resolve, reject) => {
+    const mutation = gql`
+      mutation createTodo {
+        createTodo { id, text, completed }
+      }
+    `;
+
+    const mutationData = {
+      createTodo: {
+        id: '99',
+        text: 'This one was created with a mutation.',
+        completed: true,
+      },
+    };
+
+    let todoUpdateQueryCount = 0;
+
+    const updateQueries = {
+      todos: (previousQueryResult, { mutationResult, queryVariables }) => {
+        todoUpdateQueryCount++;
+
+        if (queryVariables.id !== '123') {
+          // this isn't the query we updated, so just return the previous result
+          return previousQueryResult;
+        }
+        // otherwise, create a new object with the same shape as the
+        // previous result with the mutationResult incorporated
+        const originalList = previousQueryResult.todo_list;
+        const newTask = mutationResult.data.createTodo;
+        return {
+          todo_list: assign(originalList, { tasks: [...originalList.tasks, newTask] }),
+        };
+      },
+    };
+
+    const query = gql`
+      query todos($id: ID!) {
+        todo_list(id: $id) {
+          id, title, tasks { id, text, completed }
+        }
+      }
+    `;
+
+    const data = {
+      todo_list: { id: '123', title: 'how to apollo', tasks: [] },
+    };
+
+    const networkInterface = mockNetworkInterface(
+      { request: { query, variables: { id: '123' } }, result: { data } },
+      { request: { query: mutation }, result: { data: mutationData } },
+      { request: { query: mutation }, result: { data: mutationData } },
+    );
+    const client = new ApolloClient({ networkInterface, addTypename: false });
+
+    let mutate;
+
+    @graphql(mutation, { options: () => ({ updateQueries }) })
+    class Mutation extends React.Component<any, any> {
+      componentDidMount () {
+        mutate = this.props.mutate;
+      }
+
+      render () {
+        return null;
+      }
+    }
+
+    let queryMountCount = 0;
+    let queryUnmountCount = 0;
+    let queryRenderCount = 0;
+
+    @graphql(query)
+    class Query extends React.Component<any, any> {
+      componentWillMount () {
+        queryMountCount++;
+      }
+
+      componentWillUnmount () {
+        queryUnmountCount++;
+      }
+
+      render () {
+        try {
+          switch (queryRenderCount++) {
+            case 0:
+              expect(this.props.data.loading).toBe(true);
+              expect(this.props.data.todo_list).toBeFalsy();
+              break;
+            case 1:
+              expect(this.props.data.todo_list).toEqual({
+                id: '123',
+                title: 'how to apollo',
+                tasks: [],
+              });
+              break;
+            case 2:
+              expect(queryMountCount).toBe(1);
+              expect(queryUnmountCount).toBe(0);
+              expect(this.props.data.todo_list).toEqual({
+                id: '123',
+                title: 'how to apollo',
+                tasks: [
+                  {
+                    id: '99',
+                    text: 'This one was created with a mutation.',
+                    completed: true,
+                  },
+                ],
+              });
+              break;
+            case 3:
+              expect(queryMountCount).toBe(2);
+              expect(queryUnmountCount).toBe(1);
+              expect(this.props.data.todo_list).toEqual({
+                id: '123',
+                title: 'how to apollo',
+                tasks: [
+                  {
+                    id: '99',
+                    text: 'This one was created with a mutation.',
+                    completed: true,
+                  },
+                  {
+                    id: '99',
+                    text: 'This one was created with a mutation.',
+                    completed: true,
+                  },
+                ],
+              });
+              break;
+            case 4:
+              expect(this.props.data.todo_list).toEqual({
+                id: '123',
+                title: 'how to apollo',
+                tasks: [
+                  {
+                    id: '99',
+                    text: 'This one was created with a mutation.',
+                    completed: true,
+                  },
+                  {
+                    id: '99',
+                    text: 'This one was created with a mutation.',
+                    completed: true,
+                  },
+                ],
+              });
+              break;
+            default:
+              throw new Error('Rendered too many times');
+          }
+        } catch (error) {
+          reject(error);
+        }
+        return null;
+      }
+    }
+
+    const wrapperMutation = renderer.create(
+      <ApolloProvider client={client}>
+        <Mutation/>
+      </ApolloProvider>
+    );
+
+    const wrapperQuery1 = renderer.create(
+      <ApolloProvider client={client}>
+        <Query id="123"/>
+      </ApolloProvider>
+    );
+
+    setTimeout(() => {
+      mutate();
+
+      setTimeout(() => {
+        try {
+          expect(queryUnmountCount).toBe(0);
+          wrapperQuery1.unmount();
+          expect(queryUnmountCount).toBe(1);
+        } catch (error) {
+          reject(error);
+          throw error;
+        }
+
+        setTimeout(() => {
+          mutate();
+
+          setTimeout(() => {
+            const wrapperQuery2 = renderer.create(
+              <ApolloProvider client={client}>
+                <Query id="123"/>
+              </ApolloProvider>
+            );
+
+            setTimeout(() => {
+              wrapperMutation.unmount();
+              wrapperQuery2.unmount();
+
+              try {
+                expect(todoUpdateQueryCount).toBe(2);
+                expect(queryMountCount).toBe(2);
+                expect(queryUnmountCount).toBe(2);
+                expect(queryRenderCount).toBe(5);
+                resolve();
+              } catch (error) {
+                reject(error);
+                throw error;
+              }
+            }, 5);
+          }, 5);
+        }, 5);
+      }, 5);
+    }, 5);
+  }));
+
 });

--- a/test/react-web/client/graphql/mutations.test.tsx
+++ b/test/react-web/client/graphql/mutations.test.tsx
@@ -394,6 +394,25 @@ describe('mutations', () => {
     renderer.create(<ApolloProvider client={client}><Container id={'123'} /></ApolloProvider>);
   });
 
+  // This is a long test that keeps track of a lot of stuff. It is testing
+  // whether or not the `updateQueries` reducers will run even when a given
+  // container component is unmounted.
+  //
+  // It does this with the following procedure:
+  //
+  // 1. Mount a mutation component.
+  // 2. Mount a query component.
+  // 3. Run the mutation in the mutation component.
+  // 4. Check the props in the query component.
+  // 5. Unmount the query component.
+  // 6. Run the mutation in the mutation component again.
+  // 7. Remount the query component.
+  // 8. Check the props in the query component to confirm that the mutation
+  //    that was run while we were unmounted changed the query component’s
+  //    props.
+  //
+  // There are also a lot more assertions on the way to make sure everything is
+  // going as smoothly as planned.
   it('will run `updateQueries` for a previously mounted component', () => new Promise((resolve, reject) => {
     const mutation = gql`
       mutation createTodo {

--- a/test/react-web/client/graphql/queries.test.tsx
+++ b/test/react-web/client/graphql/queries.test.tsx
@@ -2300,6 +2300,13 @@ describe('queries', () => {
       expect(Object.keys((client as any).queryManager.observableQueries)).toEqual(['1', '2']);
       const queryObservable3 = (client as any).queryManager.observableQueries['1'].observableQuery;
       const queryObservable4 = (client as any).queryManager.observableQueries['2'].observableQuery;
+
+      // What we really want to test here is if the `queryObservable` on
+      // `Container`s are referentially equal. But because there is no way to
+      // get the component instances we compare against the query manager
+      // observable queries map isntead which shouldn’t change.
+      expect(queryObservable3).not.toBeFalsy();
+      expect(queryObservable4).not.toBeFalsy();
       expect(queryObservable3).toBe(queryObservable1);
       expect(queryObservable4).toBe(queryObservable2);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "./typings.d.ts",
     "./src/index.ts",
     "./src/server.ts",
-    "./src/test-utils.tsx"
+    "./src/test-utils.tsx",
+    "./test/**/*.ts",
+    "./test/**/*.tsx"
   ],
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,7 @@
     "./typings.d.ts",
     "./src/index.ts",
     "./src/server.ts",
-    "./src/test-utils.tsx",
-    "./test/**/*.ts",
-    "./test/**/*.tsx"
+    "./src/test-utils.tsx"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR is our first attempt to solve the `updateQueries` regression introduced by `apollo-client` version `0.5.22` in a bug fix while still trying to keep the bug that got fixed, well, fixed.

The issue is that when `updateQueries` or a `reducer` references data for a component which has been unmounted then there is no way to update data in the store at that location. So say you had an app where the user moved to a comment entry screen and your comments list component was unmounted. The user enters a comment and submits a mutation with an `updateQueries` that references the query for the unmounted comments list component. The `updateQueries` function would not run in this environment because of our bug fix.

Before `0.5.22` line [502 of `src/core/ObservableQuery.ts`](https://github.com/apollographql/apollo-client/blob/eada9a50e9a47fc4631a789b687e511d80892a33/src/core/ObservableQuery.ts#L502) did not remove the `ObservableQuery` from `QueryManager` even when it was added earlier along in the observable query’s lifecycle. This behavior was incorrect and caused https://github.com/apollographql/apollo-client/issues/993. So we fixed it! However, as a side effect of not removing the `ObservableQuery` from `QueryManager` any `ObservableQuery`s on unmounted components were updated. In short, the bug had a desirable side affect!

This PR aims to mitigate the problem which caused https://github.com/apollographql/apollo-client/issues/993 while still providing the desirable `updateQueries` behavior that many of our users expect. In order to strike this balance this PR implements `ObservableQuery` recycling. Here’s how it works.

When a component is unmounted, instead of throwing away the `ObservableQuery`, we put it in a recycler to keep it alive. You can think of it like putting the `ObservableQuery` in the fridge to be reheated later. When a new component mounts we take our saved `ObservableQuery` out of the fridge, add some new options, and use the old observable query again.

Now for every container component in your app (you create one whenever you call `graphql`) there should only be one `ObservableQuery` that lives forever assuming that you only render our container component once at a time. If you render your component more than once at a time that should still be fine.

When `ObservableQuery` is in the recycler it will receive any `updateQueries` and `reducer` store changes like normal. The only difference is that no component will re-render.

There are probably going to be a few bugs associated with this change. My assumption is that it will be much easier to smash those smaller bugs as they come up instead of letting this `updateQueries` bug live on. Those bugs will also likely be much smaller in scope.

Here are a few of the issues which can provide context on the issue. I may be missing some:

- This is the issue that prompted the bug fix which broke the `updateQueries` behavior. https://github.com/apollographql/apollo-client/issues/993
- Design for a new `updateQueries` (we determined that we needed a fix before we could implement the new design): https://github.com/apollographql/apollo-client/issues/1224
- The first bug report?: https://github.com/apollographql/apollo-client/issues/1129
- Potential duplicate bug report: https://github.com/apollographql/apollo-client/issues/1218
- Another bug report: https://github.com/apollographql/apollo-client/issues/1211
- Another bug report: https://github.com/apollographql/apollo-client/issues/1290
- Another bug report: https://github.com/apollographql/react-apollo/issues/454
- Another bug report: https://github.com/apollographql/react-apollo/issues/419
- Another bug report: https://github.com/apollographql/apollo-client/issues/1068

Basically, there were a lot of bug reports 😊. We didn’t fix this sooner because we saw the bug fix that caused this regression as technically correct, and we’re working on moving towards `apollo-client` 1.0.

I just want to write one more test to assert that the `updateQueries` behavior is ok. (because that’s why this PR was opened!)

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change