### PR TITLE
Allow ApolloProvider Prop Updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- ApolloProvider now changes it's client and store when those props change. [PR #479](https://github.com/apollographql/react-apollo/pull/479)
 
 ### 1.0.0-rc.1
 - Update dependency to Apollo Client 1.0.0-rc.1 [PR #520](https://github.com/apollographql/react-apollo/pull/520)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
-- ApolloProvider now changes it's client and store when those props change. [PR #479](https://github.com/apollographql/react-apollo/pull/479)
+- ApolloProvider now changes its client and store when those props change. [PR #479](https://github.com/apollographql/react-apollo/pull/479)
 
 ### 1.0.0-rc.1
 - Update dependency to Apollo Client 1.0.0-rc.1 [PR #520](https://github.com/apollographql/react-apollo/pull/520)

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "enzyme-to-json": "^1.1.5",
     "flow-bin": "^0.41.0",
     "graphql": "^0.9.1",
+    "graphql-tools": "^0.10.1",
     "gzip-size": "^3.0.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -10,7 +10,9 @@ import {
   Store,
 } from 'redux';
 
-import ApolloClient from 'apollo-client';
+/* tslint:disable:no-unused-variable */
+import ApolloClient, { ApolloStore } from 'apollo-client';
+/* tslint:enable:no-unused-variable */
 
 import invariant = require('invariant');
 
@@ -37,44 +39,32 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     client: PropTypes.object.isRequired,
   };
 
-  public store: Store<any>;
-  public client: ApolloClient;
-
   constructor(props, context) {
     super(props, context);
 
-    this._init(props);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this._init(nextProps);
-  }
-
-  _init(props) {
     invariant(
       props.client,
       'ApolloClient was not passed a client instance. Make ' +
       'sure you pass in your client via the "client" prop.',
     );
 
-    this.client = props.client;
+    if (!props.store) { props.client.initStore(); }
+  }
 
-    if (props.store) {
-      this.store = props.store;
-      // support an immutable store alongside apollo store
-      if (props.immutable) props.client.initStore();
-      return;
-    }
+  shouldComponentUpdate(nextProps) {
+    return this.props.client !== nextProps.client ||
+      this.props.store !== nextProps.store ||
+      this.props.children !== nextProps.children;
+  }
 
-    // intialize the built in store if none is passed in
-    props.client.initStore();
-    this.store = props.client.store;
+  componentDidUpdate() {
+    if (!this.props.store) { this.props.client.initStore(); }
   }
 
   getChildContext() {
     return {
-      store: this.store,
-      client: this.client,
+      store: this.props.store || this.props.client.store,
+      client: this.props.client,
     };
   }
 

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -43,6 +43,15 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
   constructor(props, context) {
     super(props, context);
 
+    this._init(props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this._init(nextProps);
+  }
+
+  _init(props) {
+
     invariant(
       props.client,
       'ApolloClient was not passed a client instance. Make ' +
@@ -61,7 +70,6 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     // intialize the built in store if none is passed in
     props.client.initStore();
     this.store = props.client.store;
-
   }
 
   getChildContext() {

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -51,7 +51,6 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
   }
 
   _init(props) {
-
     invariant(
       props.client,
       'ApolloClient was not passed a client instance. Make ' +

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -48,7 +48,9 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
       'sure you pass in your client via the "client" prop.',
     );
 
-    if (!props.store) { props.client.initStore(); }
+    if (!props.store) {
+      props.client.initStore();
+    }
   }
 
   shouldComponentUpdate(nextProps) {
@@ -57,8 +59,10 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
       this.props.children !== nextProps.children;
   }
 
-  componentDidUpdate() {
-    if (!this.props.store) { this.props.client.initStore(); }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.client !== this.props.client && !nextProps.store) {
+      nextProps.client.initStore();
+    }
   }
 
   getChildContext() {

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -259,11 +259,24 @@ export default function graphql(
         }
       }
 
-      componentWillReceiveProps(nextProps) {
-        if (shallowEqual(this.props, nextProps)) return;
+      componentWillReceiveProps(nextProps, nextContext) {
+        if (shallowEqual(this.props, nextProps) && this.client === nextContext.client) {
+          return;
+        }
 
         this.shouldRerender = true;
 
+        if (this.client !== nextContext.client) {
+          this.client = nextContext.client;
+          this.unsubscribeFromQuery();
+          this.queryObservable = null;
+          this.previousData = {};
+          this.updateQuery(nextProps);
+          if (!this.shouldSkip(nextProps)) {
+            this.subscribeToQuery();
+          }
+          return;
+        }
         if (this.type === DocumentType.Mutation) {
           return;
         };

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -22,6 +22,7 @@ export class MockedProvider extends React.Component<any, any> {
 
   constructor(props, context) {
     super(props, context);
+    if (this.props.client) return;
 
     const networkInterface = mockNetworkInterface.apply(null, this.props.mocks);
     this.client = new ApolloClient({ networkInterface });
@@ -29,7 +30,7 @@ export class MockedProvider extends React.Component<any, any> {
 
   render() {
     return (
-      <ApolloProvider client={this.client}>
+      <ApolloProvider client={this.client || this.props.client}>
         {this.props.children}
       </ApolloProvider>
     );

--- a/test/react-native/__snapshots__/component.test.js.snap
+++ b/test/react-native/__snapshots__/component.test.js.snap
@@ -1,8 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`App renders correctly 1`] = `
 <Text
   accessible={true}
   allowFontScaling={true}
-  ellipsizeMode="tail">
+  ellipsizeMode="tail"
+>
   Loading...
 </Text>
 `;

--- a/test/react-native/__snapshots__/component.test.js.snap
+++ b/test/react-native/__snapshots__/component.test.js.snap
@@ -1,11 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
 exports[`App renders correctly 1`] = `
 <Text
   accessible={true}
   allowFontScaling={true}
-  ellipsizeMode="tail"
->
+  ellipsizeMode="tail">
   Loading...
 </Text>
 `;

--- a/test/react-web/client/ApolloProvider.test.tsx
+++ b/test/react-web/client/ApolloProvider.test.tsx
@@ -1,6 +1,6 @@
 
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount, ReactWrapper } from 'enzyme';
 import { createStore } from 'redux';
 
 declare function require(name: string);
@@ -31,15 +31,15 @@ describe('<ApolloProvider /> Component', () => {
   }
   class Container extends React.Component<any, any> {
     constructor(props) {
-      super(props)
-      this.state = {}
+      super(props);
+      this.state = {};
     }
 
     componentDidMount() {
       this.setState({
         store: this.props.store,
-        client: this.props.client
-      })
+        client: this.props.client,
+      });
     }
 
     render() {
@@ -49,13 +49,13 @@ describe('<ApolloProvider /> Component', () => {
             store={this.state.store || this.props.store}>
             <Child />
           </ApolloProvider>
-        )
+        );
       } else {
         return (
           <ApolloProvider client={this.state.client || this.props.client}>
             <Child />
           </ApolloProvider>
-        )
+        );
       }
     }
   };
@@ -172,7 +172,7 @@ describe('<ApolloProvider /> Component', () => {
     container.setState({ client: newClient });
 
     expect(initStoreMock).toHaveBeenCalled();
-  })
+  });
 
   it('should not call clients init store when a store is passed', () => {
     const testClient = new ApolloClient();
@@ -195,5 +195,28 @@ describe('<ApolloProvider /> Component', () => {
     const newStore = createStore(() => ({}));
     container.setState({ store: store });
     expect(initStoreMock).not.toHaveBeenCalled();
-  })
+  });
+
+  it('child component should be able to query new client and store when props change', () => {
+    const container = TestUtils.renderIntoDocument(
+      <Container client={client} store={store} />
+    ) as React.Component<any, any>;
+
+    const child = TestUtils.findRenderedComponentWithType(container, Child);
+    expect(child.context.client).toEqual(client);
+    expect(child.context.store).toEqual(store);
+
+    const newClient = new ApolloClient({});
+    const newStore = createStore(() => ({}));
+
+    container.setState({
+      client: newClient,
+      store: newStore,
+    });
+
+    expect(child.context.client).toEqual(newClient);
+    expect(child.context.store).toEqual(newStore);
+    expect(child.context.client).not.toEqual(client);
+    expect(child.context.store).not.toEqual(store);
+  });
 });

--- a/test/react-web/client/graphql/queries.test.tsx
+++ b/test/react-web/client/graphql/queries.test.tsx
@@ -26,6 +26,9 @@ const wrap = (done: Function, cb: (...args: any[]) => any) => (...args: any[]) =
   }
 };
 
+function wait(ms) {
+  return new Promise(resolve => setTimeout(() => resolve(), ms));
+}
 
 describe('queries', () => {
 
@@ -2420,5 +2423,85 @@ describe('queries', () => {
       }
     }, 20);
   }));
+
+  it('will re-execute a query when the client changes', async () => {
+    const query = gql`{ a b c }`;
+    const networkInterface1 = { query: jest.fn(() => Promise.resolve({ data: { a: 1, b: 2, c: 3 } })) };
+    const networkInterface2 = { query: jest.fn(() => Promise.resolve({ data: { a: 4, b: 5, c: 6 } })) };
+    const networkInterface3 = { query: jest.fn(() => Promise.resolve({ data: { a: 7, b: 8, c: 9 } })) };
+    const client1 = new ApolloClient({ networkInterface: networkInterface1 });
+    const client2 = new ApolloClient({ networkInterface: networkInterface2 });
+    const client3 = new ApolloClient({ networkInterface: networkInterface3 });
+    const renders = [];
+    let switchClient;
+    let refetchQuery;
+
+    class ClientSwitcher extends React.Component<any, any> {
+      state = {
+        client: client1,
+      };
+
+      componentDidMount() {
+        switchClient = newClient => {
+          this.setState({ client: newClient });
+        };
+      }
+
+      render() {
+        return (
+          <ApolloProvider client={this.state.client}>
+            <Query/>
+          </ApolloProvider>
+        );
+      }
+    }
+
+    @graphql(query)
+    class Query extends React.Component<any, any> {
+      componentDidMount() {
+        refetchQuery = () => this.props.data.refetch();
+      }
+
+      render() {
+        const { data: { loading, a, b, c } } = this.props;
+        renders.push({ loading, a, b, c });
+        return null;
+      }
+    }
+
+    renderer.create(<ClientSwitcher/>);
+
+    await wait(1);
+    refetchQuery();
+    await wait(1);
+    switchClient(client2);
+    await wait(1);
+    refetchQuery();
+    await wait(1);
+    switchClient(client3);
+    await wait(1);
+    switchClient(client1);
+    await wait(1);
+    switchClient(client2);
+    await wait(1);
+    switchClient(client3);
+    await wait(1);
+
+    expect(renders).toEqual([
+      { loading: true },
+      { loading: false, a: 1, b: 2, c: 3 },
+      { loading: true, a: 1, b: 2, c: 3 },
+      { loading: false, a: 1, b: 2, c: 3 },
+      { loading: true },
+      { loading: false, a: 4, b: 5, c: 6 },
+      { loading: true, a: 4, b: 5, c: 6 },
+      { loading: false, a: 4, b: 5, c: 6 },
+      { loading: true },
+      { loading: false, a: 7, b: 8, c: 9 },
+      { loading: false, a: 1, b: 2, c: 3 },
+      { loading: false, a: 4, b: 5, c: 6 },
+      { loading: false, a: 7, b: 8, c: 9 },
+    ]);
+  });
 
 });


### PR DESCRIPTION
We have a use case in React Native where we switch the GraphQL endpoint dynamically while the app is running. This PR changes the ApolloProvider API by updating it's client and store when new props are delivered to the provider.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change