### PR TITLE
Extend ApolloProvider and graphql API to support multiple clients.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- Extend ApolloProvider and graphql API to support multiple clients. [PR #481](https://github.com/apollographql/react-apollo/pull/481)
 
 ### 0.11.2
 - Remove `@types/chai` dev dependency which called a reference to the `chai` types in the production build. [PR #471](https://github.com/apollographql/react-apollo/pull/471)

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -18,7 +18,8 @@ export declare interface ProviderProps {
   store?: Store<any>;
   immutable?: boolean;
   client: ApolloClient;
-}
+  as?: string;
+};
 
 export default class ApolloProvider extends Component<ProviderProps, any> {
   static propTypes = {
@@ -30,15 +31,22 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     client: PropTypes.object.isRequired,
     immutable: PropTypes.bool,
     children: PropTypes.element.isRequired,
+    as: PropTypes.string,
+  };
+  static defaultProps = {
+    as: 'default',
   };
 
+  static contextTypes = { apolloClients: PropTypes.object };
   static childContextTypes = {
+    apolloClients: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
-    client: PropTypes.object.isRequired,
   };
 
   public store: Store<any>;
   public client: ApolloClient;
+  public previousClients: Object;
+  public as: string;
 
   constructor(props, context) {
     super(props, context);
@@ -49,6 +57,7 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
       'sure you pass in your client via the "client" prop.'
     );
 
+    this.previousClients = context.apolloClients || {};
     this.client = props.client;
 
     if (props.store) {
@@ -65,9 +74,12 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
   }
 
   getChildContext() {
+    // can be replaced with object spread from typescript 2.1
     return {
+      apolloClients: Object.assign(
+        {}, this.previousClients, { [this.props.as]: this.client }
+      ),
       store: this.store,
-      client: this.client,
     };
   }
 

--- a/test/react-web/client/ApolloProvider.test.tsx
+++ b/test/react-web/client/ApolloProvider.test.tsx
@@ -11,15 +11,15 @@ import ApolloClient from 'apollo-client';
 import ApolloProvider  from '../../../src/ApolloProvider';
 
 interface ChildContext {
+  apolloClients: Object;
   store: Object;
-  client: Object;
 }
 
 describe('<ApolloProvider /> Component', () => {
 
   class Child extends React.Component<any, { store: any, client: any}> {
     static contextTypes: React.ValidationMap<any> = {
-      client: React.PropTypes.object.isRequired,
+      apolloClients: React.PropTypes.object.isRequired,
       store: React.PropTypes.object.isRequired,
     };
 
@@ -80,7 +80,7 @@ describe('<ApolloProvider /> Component', () => {
     console.error = originalConsoleError;
   });
 
-  it('should add the client to the child context', () => {
+  it('should add the default client to the child context', () => {
     const tree = TestUtils.renderIntoDocument(
       <ApolloProvider store={store} client={client}>
         <Child />
@@ -88,7 +88,19 @@ describe('<ApolloProvider /> Component', () => {
     ) as React.Component<any, any>;
 
     const child = TestUtils.findRenderedComponentWithType(tree, Child);
-    expect(child.context.client).toEqual(client);
+    expect(child.context.apolloClients.default).toEqual(client);
+
+  });
+
+  it('should add extra clients to the child context', () => {
+    const tree = TestUtils.renderIntoDocument(
+      <ApolloProvider client={client} as="extraClient">
+        <Child />
+      </ApolloProvider>
+    ) as React.Component<any, any>;
+
+    const child = TestUtils.findRenderedComponentWithType(tree, Child);
+    expect(child.context.apolloClients.extraClient).toEqual(client);
 
   });
 


### PR DESCRIPTION
Related discussion: #464 
Documentation PR: https://github.com/apollographql/react-docs/pull/163

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
