### PR TITLE
Ensure that SSR completes when the GraphQL server throws errors.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -128,7 +128,13 @@ export function getDataFromTree(rootElement, rootContext: any = {}, fetchRoot: b
   // wait on each query that we found, re-rendering the subtree when it's done
   const mappedQueries = queries.map(({ query, element, context }) =>  {
     // we've just grabbed the query for element, so don't try and get it again
-    return query.then(_ => getDataFromTree(element, context, false));
+    return query.then(_ => getDataFromTree(element, context, false))
+      // If there's an error in the query, we may as well stop, as currently
+      // we will "forget" this when the "rendering" SSR runs (i.e. we will
+      // re-run the query, and rendering in a loading state).
+      // If we change that in future, it may be worth running `getDataFromTree`
+      // on the subtree, just in case the user runs subqueries in the error state
+      .catch(e => null);
   });
   return Promise.all(mappedQueries).then(_ => null);
 }

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -263,6 +263,30 @@ describe('SSR', () => {
         ;
     });
 
+    it('should handle errors thrown by queries', () => {
+      const query = gql`{ currentUser { firstName } }`;
+      const networkInterface = mockNetworkInterface(
+        { request: { query }, error: new Error('Failed to fetch'), delay: 50 }
+      );
+      const apolloClient = new ApolloClient({ networkInterface, addTypename: false });
+
+      const WrappedElement = graphql(query)(({ data }) => (
+        <div>{data.loading ? 'loading' : data.error}</div>
+      ));
+
+      const Page = () => (<div><span>Hi</span><div><WrappedElement /></div></div>);
+
+      const app = (<ApolloProvider client={apolloClient}><Page/></ApolloProvider>);
+
+      return getDataFromTree(app)
+        .then(() => {
+          const markup = ReactDOM.renderToString(app);
+          // It renders in a loading state as errored query isn't shared between
+          // the query fetching run and the rendering run.
+          expect(markup).toMatch(/loading/);
+        });
+    });
+
     it('should correctly skip queries (deprecated)', () => {
 
       const query = gql`{ currentUser { firstName } }`;


### PR DESCRIPTION
See #406.

We still end up rendering a loading screen but that is better than
just bailing out of SSR completely.


TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
