### PR TITLE
Stop polling in server side rendering

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -432,7 +432,9 @@ export default function graphql(
         const result = observable.currentResult();
 
         if (result.loading) {
-          return observable.result();
+          const result = observable.result();
+          observable.stopPolling();
+          return result;
         } else {
           return false;
         }


### PR DESCRIPTION
This is a quick solution to https://github.com/apollographql/apollo-client/issues/1334. The correct solution would be to never start polling in the first place. If someone wants to add a test for this, it would be much appreciated because I may not get to it in a bit.

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change