### PR TITLE
Bumping `graphql-tag`, ignoring deprecation warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 
+### 0.13.2
+- Address deprecation warnings coming from `graphql-tag` [graphql-tag#54](https://github.com/apollographql/graphql-tag/issues/54)
+
 ### 0.13.1
 - Add apollo-client ^0.10.0 to dependency range
 

--- a/examples/create-react-app/src/Pokemon.test.js
+++ b/examples/create-react-app/src/Pokemon.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { MockedProvider } from '../../../lib/test-utils';
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 import { addTypenameToDocument } from 'apollo-client/queries/queryTransform';
 
 import PokemonWithData, { POKEMON_QUERY, Pokemon, withPokemon } from './Pokemon';

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   "dependencies": {
     "apollo-client": "^0.9.0 || ^0.10.0",
     "graphql-anywhere": "^2.0.0",
-    "graphql-tag": "^1.2.4",
+    "graphql-tag": "^1.3.1",
     "hoist-non-react-statics": "^1.2.0",
     "invariant": "^2.2.1",
     "lodash.flatten": "^4.2.0",

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -12,7 +12,7 @@ import {
   DocumentNode,
 } from 'graphql';
 
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql-tag/bundledPrinter';
 
 
 import ApolloProvider from './ApolloProvider';


### PR DESCRIPTION
`graphql-tag` has deprecated the export of the `printer` export (which we use for various AST-related tasks here in `react-apollo`). when `graphql-tag@v2` comes out, we can switch to using the printer / parser from the `graphql` package, but for now we know about the deprecation warning and can safely ignore it.

addresses [graphql-tag#54](https://github.com/apollographql/graphql-tag/issues/54)

TODO:

- [ ] ~Make sure all of the significant new logic is covered by tests~
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] Add your name and email to the AUTHORS file (optional)
- [ ] ~If this was a change that affects the external API, update the docs and post a link to the PR in the discussion~
