### PR TITLE
Don't strip data away from the component when the query errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- Include cached data in failed queries
 
 ### 0.13.1
 - Add apollo-client ^0.10.0 to dependency range

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -557,6 +557,9 @@ export default function graphql(
           if (loading) {
             // while loading, we should use any previous data we have
             assign(data, this.previousData, currentResult.data);
+          } else if (error) {
+            // if there is an error, also provide previous data so it can be displayed along with the error
+            assign(data, this.previousData)
           } else {
             assign(data, currentResult.data);
             this.previousData = currentResult.data;


### PR DESCRIPTION
Motivation: in our UI, we want to display an error screen when a query fails (typically because of connectivity loss).  But we want the user to also see the cached data.  The current version does not include any cached data when there is an error.  This PR fixes that.

Old behavior: if there was an error, don't include any data with the query results
New behavior: if there was an error, include data from the previous successful request

In fact, this was done about 6 months ago by @rricard but then somehow removed: https://github.com/apollographql/react-apollo/pull/98
