### PR TITLE
Change uncaught to unhandled

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -542,7 +542,7 @@ export default function graphql(
           // _feel_ like it was logged ASAP while still tolerating asynchrony.
           let logErrorTimeoutId = setTimeout(() => {
             if (error) {
-              console.error('Uncaught (in react-apollo)', error.stack || error);
+              console.error('Unhandled (in react-apollo)', error.stack || error);
             }
           }, 10);
           Object.defineProperty(data, 'error', {

--- a/test/react-web/client/graphql/queries.test.tsx
+++ b/test/react-web/client/graphql/queries.test.tsx
@@ -2411,7 +2411,7 @@ describe('queries', () => {
       try {
         expect(renderCount).toBe(2);
         expect(errorMock.mock.calls.length).toBe(1);
-        expect(errorMock.mock.calls[0][0]).toEqual('Uncaught (in react-apollo)');
+        expect(errorMock.mock.calls[0][0]).toEqual('Unhandled (in react-apollo)');
         resolve();
       } catch (error) {
         reject(error);


### PR DESCRIPTION
I just like “Unhandled (in react-apollo) Error …” more than “Uncaught (in react-apollo) Error …” At first I only used “uncaught” to be symmetrical with uncaught promise errors, but I have changed my mind that symmetry is important 😊