### PR TITLE
Check if WrappedComponent implementation changed since last render to fix HMR

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -577,7 +577,7 @@ export default function graphql(
         const clientProps = this.calculateResultProps(data);
         const mergedPropsAndData = assign({}, props, clientProps);
 
-        if (!shouldRerender && renderedElement) {
+        if (!shouldRerender && renderedElement && renderedElement.type === WrappedComponent) {
           return renderedElement;
         }
 


### PR DESCRIPTION
As documented in: 
https://github.com/apollographql/react-apollo/issues/174
https://github.com/apollographql/apollo-client/issues/764
https://github.com/HriBB/react-apollo-rhl-problem

Hot Module Replacement doesn't work when your component is wrapped by the GraphQL HOC. This happens because `render()` reutilizes `this.renderedElement` even though the `WrappedComponent` implementation changed during hot reloading.

- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
