### PR TITLE
fix: Move constructor initializing of props to componentWillMount

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 - Make sure that the cached rendered element has the correct type before returning it. [PR #505](https://github.com/apollographql/react-apollo/pull/505)
+- Move constructor initializing of props to componentWillMount. [PR #506](https://github.com/apollographql/react-apollo/pull/506) ([Issue #509](https://github.com/apollographql/react-apollo/issues/509)).
 
 ### 0.13.2
 - Address deprecation warnings coming from `graphql-tag` [graphql-tag#54](https://github.com/apollographql/graphql-tag/issues/54)

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -241,6 +241,15 @@ export default function graphql(
           `"${graphQLDisplayName}". ` +
           `Wrap the root component in an <ApolloProvider>`,
         );
+
+        this.store = this.client.store;
+        this.type = operation.type;
+      }
+
+      componentWillMount() {
+        if (!this.shouldSkip(this.props)) {
+          this.setInitialProps();
+        }
       }
 
       componentDidMount() {
@@ -250,15 +259,6 @@ export default function graphql(
         if (!this.shouldSkip(this.props)) {
           this.subscribeToQuery();
         }
-      }
-
-      componentWillMount() {
-        this.store = this.client.store;
-
-        this.type = operation.type;
-
-        if (this.shouldSkip(this.props)) return;
-        this.setInitialProps();
       }
 
       componentWillReceiveProps(nextProps) {

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -241,13 +241,6 @@ export default function graphql(
           `"${graphQLDisplayName}". ` +
           `Wrap the root component in an <ApolloProvider>`,
         );
-
-        this.store = this.client.store;
-
-        this.type = operation.type;
-
-        if (this.shouldSkip(props)) return;
-        this.setInitialProps();
       }
 
       componentDidMount() {
@@ -257,6 +250,15 @@ export default function graphql(
         if (!this.shouldSkip(this.props)) {
           this.subscribeToQuery();
         }
+      }
+
+      componentWillMount() {
+        this.store = this.client.store;
+
+        this.type = operation.type;
+
+        if (this.shouldSkip(this.props)) return;
+        this.setInitialProps();
       }
 
       componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
React outputs setState warnings (constructor side-effects are an anti-pattern), because of that initializing of props in the constructor and by moving that code to componentWillMount fixes that.

