### PR TITLE
Fix #312

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
 ### vNext
+- Fix bug where `options` was mutated causing variables to not update appropriately. [PR #537](https://github.com/apollographql/react-apollo/pull/537)
 
 ### 1.0.0-rc.1
 - Update dependency to Apollo Client 1.0.0-rc.1 [PR #520](https://github.com/apollographql/react-apollo/pull/520)

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -340,7 +340,7 @@ export default function graphql(
             `passed to '${graphQLDisplayName}'`,
           );
         }
-        opts.variables = variables;
+        opts = { ...opts, variables };
         return opts;
       };
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/react-apollo/issues/312

cc @drager, @steventebrinke

We were mutating the `options` object where we weren’t supposed to. So if a user had used an object instead of a function for their `options` then in some cases we would be setting the `variables` property incorrectly. I found the bug by calling `Object.freeze` on `options` if it was not a function.

There error was reproduced in: https://github.com/steventebrinke/react-apollo-error-template/commit/e80ca5ed7a89cbed0b7d39f44d24ffb433f3e111