### PR TITLE
Include cached data with error

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -558,8 +558,16 @@ export default function graphql(
             // while loading, we should use any previous data we have
             assign(data, this.previousData, currentResult.data);
           } else {
-            assign(data, currentResult.data);
-            this.previousData = currentResult.data;
+            let dataToMerge = currentResult.data;
+            // if we have an error, include any previously cached data
+            if (error) {
+              let previousResult = this.queryObservable.getLastResult()
+              if (previousResult && !previousResult.error) {
+                dataToMerge = assign({}, previousResult.data, currentResult.data)
+              }
+            }
+            assign(data, dataToMerge);
+            this.previousData = dataToMerge;
           }
         }
         return data;

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -561,9 +561,9 @@ export default function graphql(
             let dataToMerge = currentResult.data;
             // if we have an error, include any previously cached data
             if (error) {
-              let previousResult = this.queryObservable.getLastResult()
+              let previousResult = this.queryObservable.getLastResult();
               if (previousResult && !previousResult.error) {
-                dataToMerge = assign({}, previousResult.data, currentResult.data)
+                dataToMerge = assign({}, previousResult.data, currentResult.data);
               }
             }
             assign(data, dataToMerge);


### PR DESCRIPTION
This PR includes data cached from the Apollo store when there is an error while fetching the query.  Now useful data can be displayed along with any error message.

For example, the server is down.  An error will be returned as it always was.  But until now, the `data` prop was empty.  A good UI for this situation would be to display an error message like "There was an error reaching our servers.  Until the problem is fixed, you can still use the app.  Your data might just be a bit off." and show the cached data.  Now you can!
