### PR TITLE
fix: Pass store prop from MockedProvider to ApolloProvider for parity

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Expect active development and potentially significant breaking changes in the `0
 
 ### vNext
 - ApolloProvider now won't put its `store` on `context` unless it was given. [PR #550](https://github.com/apollographql/react-apollo/pull/550)
+- MockedProvider now accepts a `store` prop to be passed to ApolloProvider so that react-redux store is not overwritten
 
 ### 1.0.0-rc.3
 - Fix bug where `options` was mutated causing variables to not update appropriately. [PR #537](https://github.com/apollographql/react-apollo/pull/537)

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -30,7 +30,7 @@ export class MockedProvider extends React.Component<any, any> {
 
   render() {
     return (
-      <ApolloProvider client={this.client || this.props.client}>
+      <ApolloProvider client={this.client || this.props.client} store={this.props.store || null}>
         {this.props.children}
       </ApolloProvider>
     );
@@ -107,11 +107,11 @@ export class MockNetworkInterface implements NetworkInterface {
       if (!mockedResponse.result && !mockedResponse.error) {
         throw new Error('Mocked response should contain either result or error.');
       }
-      this.addMockedReponse(mockedResponse);
+      this.addMockedResponse(mockedResponse);
     });
   }
 
-  public addMockedReponse(mockedResponse: MockedResponse) {
+  public addMockedResponse(mockedResponse: MockedResponse) {
     const key = requestToKey(mockedResponse.request);
     let mockedResponses = this.mockedResponsesByKey[key];
     if (!mockedResponses) {


### PR DESCRIPTION
MockedProvider did not pass any `store` prop down to the ApolloProvider where it can be handled appropriately. This caused the MockedProvider to override the redux store and cause my tests to fail. 

This change simply passes it along so that ApolloProvider can use it like normal.
Also fixed a typo.