### PR TITLE
exposed createBatchingNetworkInterface from apollo-client

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Expect active development and potentially significant breaking changes in the `0.x` track. We'll try to be diligent about releasing a `1.0` version in a timely fashion (ideally within 1 or 2 months), so that we can take advantage of SemVer to signify breaking changes from that point on.
 
+### vNext
+- Exposed `createBatchingNetworkInterface` from apollo-client so that it can be imported from react-apollo just like `createNetworkInterface`. [PR #618](https://github.com/apollographql/react-apollo/pull/618)
+
 ### 1.0.1
 - Fix: Make sure recycled queries are in cache only mode so they do not trigger network requests. [PR #531](https://github.com/apollographql/react-apollo/pull/531)
 
@@ -13,7 +16,6 @@ Expect active development and potentially significant breaking changes in the `0
 - Fix bug where `options` was mutated causing variables to not update appropriately. [PR #537](https://github.com/apollographql/react-apollo/pull/537)
 - Make sure that all queries resolve or reject if an error was thrown when server side rendering. [PR #488](https://github.com/apollographql/react-apollo/pull/488)
 - ApolloProvider now changes its client and store when those props change. [PR #479](https://github.com/apollographql/react-apollo/pull/479)
-- Exposed `createBatchingNetworkInterface` from `apollo-client` so that it can be imported from `react-apollo` just like `createNetworkInterface`. [PR #618](https://github.com/apollographql/react-apollo/pull/618)
 
 ### 1.0.0-rc.1
 - Update dependency to Apollo Client 1.0.0-rc.1 [PR #520](https://github.com/apollographql/react-apollo/pull/520)

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Expect active development and potentially significant breaking changes in the `0
 - Fix bug where `options` was mutated causing variables to not update appropriately. [PR #537](https://github.com/apollographql/react-apollo/pull/537)
 - Make sure that all queries resolve or reject if an error was thrown when server side rendering. [PR #488](https://github.com/apollographql/react-apollo/pull/488)
 - ApolloProvider now changes its client and store when those props change. [PR #479](https://github.com/apollographql/react-apollo/pull/479)
+- Exposed `createBatchingNetworkInterface` from `apollo-client` so that it can be imported from `react-apollo` just like `createNetworkInterface`. [PR #618](https://github.com/apollographql/react-apollo/pull/618)
 
 ### 1.0.0-rc.1
 - Update dependency to Apollo Client 1.0.0-rc.1 [PR #520](https://github.com/apollographql/react-apollo/pull/520)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,5 +6,5 @@ export { default as graphql, withApollo, InjectedGraphQLProps } from './graphql'
 export { compose } from 'redux';
 
 // re-exports of close dependencies.
-export { default as ApolloClient, createNetworkInterface } from 'apollo-client';
+export { default as ApolloClient, createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
 export { default as gql } from 'graphql-tag'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ export * from './browser';
 
 export { getDataFromTree, renderToStringWithData } from './server';
 
-export { default as ApolloClient, createNetworkInterface } from 'apollo-client';
+export { default as ApolloClient, createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
 export { default as gql } from 'graphql-tag'


### PR DESCRIPTION
Exposed `createBatchingNetworkInterface` from apollo-client so that it can be imported from react-apollo just like `createNetworkInterface`.

<!--
  Thanks for filing a pull request on react-apollo!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
- [x] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
