### PR TITLE
Add script to create gzipped file in development & report gzip size on weigh in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - npm run compile
   - cd examples/create-react-app && npm test && cd ../../
   - npm run filesize
-  - python node_modules/travis-weigh-in/weigh_in.py ./dist/index.min.js || true # ignore size errors
+  - python node_modules/travis-weigh-in/weigh_in.py ./dist/index.min.js.gz || true # ignore size errors
 
 # Allow Travis tests to run in containers.
 sudo: false

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "posttest": "npm run lint",
     "filesize": "npm run compile:browser && ./scripts/filesize.js --file=./dist/index.min.js --maxGzip=20",
     "compile": "tsc",
-    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/index.js --i react --i apollo-client -o=./dist/index.js && npm run minify:browser",
+    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/index.js --i react --i apollo-client -o=./dist/index.js && npm run minify:browser && npm run compress:browser",
     "minify:browser": "uglifyjs --compress --mangle --screw-ie8 -o=./dist/index.min.js -- ./dist/index.js",
+    "compress:browser": "./scripts/gzip.js --file=./dist/index.min.js",
     "watch": "tsc -w",
     "lint": "tslint 'src/*.ts*' && tslint 'test/*.ts*'"
   },
@@ -97,7 +98,6 @@
     "enzyme-to-json": "^1.1.5",
     "flow-bin": "^0.44.0",
     "graphql": "^0.9.1",
-    "gzip-size": "^3.0.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^19.0.2",

--- a/scripts/filesize.js
+++ b/scripts/filesize.js
@@ -4,7 +4,6 @@
 var Flags = require('minimist')(process.argv.slice(2)),
       Fs = require('fs'),
       Path = require('path'),
-      GzipSize = require('gzip-size'),
       PrettyBytes = require('pretty-bytes'),
       Colors = require('colors');
 
@@ -18,7 +17,7 @@ let totalSize = 0,
 
 var rawSize = Fs.statSync(filePath).size;
 totalSize = PrettyBytes(rawSize);
-var rawGzippedSize = GzipSize.sync(Fs.readFileSync(filePath, 'utf8'));
+var rawGzippedSize = Fs.statSync(`${filePath}.gz`).size;
 totalGzippedSize = PrettyBytes(rawGzippedSize);
 
 console.log('\n');

--- a/scripts/gzip.js
+++ b/scripts/gzip.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+
+var Flags = require('minimist')(process.argv.slice(1)),
+      Fs = require('fs'),
+      Path = require('path'),
+      Zlib = require('zlib');
+
+var filePath = Path.resolve(process.cwd(), Flags.file);
+var gzip = Zlib.createGzip({level: 9});
+
+var readStream = Fs.createReadStream(filePath);
+var writeStream = Fs.createWriteStream(`${filePath}.gz`);
+
+readStream.pipe(gzip).pipe(writeStream);


### PR DESCRIPTION
Description
----------

Currently, react-apollo uses `gzip-size` to get the gzip size without writing a `.gz` file to disk. `travis-weigh-in` requires an actual file to work with, making it incompatible with `gzip-size`. 

To solve this, this PR replaces `gzip-size` with a simple script that saves the compressed gzip and uses that file for file size calculation for both `npm run filesize` and `travis-weigh-in` scripts. 

The compression strategy utilized by `/scripts/gzip.js` is identical to what's used in `gzip-size`, with both using `zlib` set to level 9. The main change is that `gzip.js` creates a `.gz` file.

Also, the added `.gz` file in `/dist` might be helpful for people wanting to use gzipped versions of `react-apollo` in development.

Summary of changes:
----------

- Add a simple `gzip.js` script to `/scripts` to create compressed gzips (used by `compress:browser`)
- Add `compress:browser` script to `package.json` to handle creation of compressed `index.js.gz` for consumption by the `filesize` and `travis-weigh-in` scripts
- Append `npm run compress:browser` to the end of `compile:browser`
- Remove `gzip-size` as a devDependency

---------

This PR addresses #574 