### PR TITLE
Remove superfluous condition in GraphQL.shouldComponentUpdate()

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -301,7 +301,7 @@ export default function graphql(
       }
 
       shouldComponentUpdate(nextProps, nextState, nextContext) {
-        return !!nextContext || this.shouldRerender;
+        return this.shouldRerender;
       }
 
       componentWillUnmount() {


### PR DESCRIPTION
While profiling a React Native app, I discovered a significant number of re-renders occurring for components decorated by the `graphql` HOC.

The proposed change is small, but with great potential for regression. Here is my reasoning for why this is safe — please scrutinize carefully:

* The `!!nextContext` condition will always evaluate to `true` because non-null `contextTypes` are [required](https://github.com/jamesreggio/react-apollo/blob/ee6a370e32d6066210afa995e71fab79d8b31f1a/src/graphql.tsx#L204) by the HOC. As such `nextContext` will always be an object containing a `{client}`.

* The `componentWillReceiveProps` method 'owns' the setting of `this.shouldRerender` and already [includes a check](https://github.com/jamesreggio/react-apollo/blob/ee6a370e32d6066210afa995e71fab79d8b31f1a/src/graphql.tsx#L262) for updates to the `{client}` in the `nextContext`.

I cannot intuit why `!!nextContext` was ever in this function, but it probably relates to code that is long dead. (Perhaps it traces back to a time before `componentWillReceiveProps` checked for a change to the client?)

If this change seems peaceful, I think it could be a boon to performance.

I'm not certain of a good way to test this, but am open to suggestions. 