### PR TITLE
failing test for #170 

### DIFF
--- a/npm-debug.log.3540064644
+++ b/npm-debug.log.3540064644
@@ -1,0 +1,24 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/bin/nodejs', '/usr/bin/npm', 'run', 'test--watch' ]
+2 info using npm@3.10.10
+3 info using node@v6.10.0
+4 verbose stack Error: missing script: test--watch
+4 verbose stack     at run (/usr/lib/node_modules/npm/lib/run-script.js:151:19)
+4 verbose stack     at /usr/lib/node_modules/npm/lib/run-script.js:61:5
+4 verbose stack     at /usr/lib/node_modules/npm/node_modules/read-package-json/read-json.js:356:5
+4 verbose stack     at checkBinReferences_ (/usr/lib/node_modules/npm/node_modules/read-package-json/read-json.js:320:45)
+4 verbose stack     at final (/usr/lib/node_modules/npm/node_modules/read-package-json/read-json.js:354:3)
+4 verbose stack     at then (/usr/lib/node_modules/npm/node_modules/read-package-json/read-json.js:124:5)
+4 verbose stack     at /usr/lib/node_modules/npm/node_modules/read-package-json/read-json.js:311:12
+4 verbose stack     at /usr/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:78:16
+4 verbose stack     at tryToString (fs.js:455:3)
+4 verbose stack     at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:442:12)
+5 verbose cwd /mnt/c/Users/james.baxley/Products/apollo/react-apollo
+6 error Linux 4.4.0-43-Microsoft
+7 error argv "/usr/bin/nodejs" "/usr/bin/npm" "run" "test--watch"
+8 error node v6.10.0
+9 error npm  v3.10.10
+10 error missing script: test--watch
+11 error If you need help, you may report this error at:
+11 error     <https://github.com/npm/npm/issues>
+12 verbose exit [ 1, true ]


### PR DESCRIPTION
With the introduction of recycled queries, components that remount with different variables that get the same data (i.e. a null response from the server) get stuck in loading state.

This is currently just an error reproduction from https://github.com/comus/react-apollo-issue

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
- [ ] If this was a change that affects the external API, update the docs and post a link to the PR in the discussion
