### PR TITLE
fix(shouldComponentUpdate): removed from ApolloProvider

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -51,12 +51,6 @@ export default class ApolloProvider extends Component<ProviderProps, any> {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    return this.props.client !== nextProps.client ||
-      this.props.store !== nextProps.store ||
-      this.props.children !== nextProps.children;
-  }
-
   componentWillReceiveProps(nextProps) {
     if (nextProps.client !== this.props.client && !nextProps.store) {
       nextProps.client.initStore();


### PR DESCRIPTION
Is causing issues when `ApolloProvider` is used with other Providers (eg: react-router).
`shouldComponentUpdate` is an unnecessary here, it is used to stop unnecessary updates caused by higher components. But as `ApolloProvider` should be near the top of the tree, it can be assumed that ALL updates passed to is are necessary.

fixes issue: #557  
