### PR TITLE
move type imports to root of AC for easier local dev / ci testing

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -23,17 +23,11 @@ import ApolloClient, {
   ApolloQueryResult,
   ApolloError,
   FetchPolicy,
-} from 'apollo-client';
-
-import {
   FetchMoreOptions,
   UpdateQueryOptions,
-} from 'apollo-client/core/ObservableQuery';
-
-import {
   FetchMoreQueryOptions,
   SubscribeToMoreOptions,
-} from 'apollo-client/core/watchQueryOptions';
+} from 'apollo-client';
 
 import {
   // GraphQLResult,

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -5,7 +5,7 @@ import {
   NetworkInterface,
   Request,
   SubscriptionNetworkInterface,
-} from 'apollo-client/transport/networkInterface';
+} from 'apollo-client';
 
 import {
   ExecutionResult,


### PR DESCRIPTION
Moved to using root import for types from AC. Needs to wait on https://github.com/apollographql/apollo-client/pull/1644
