### PR TITLE
recycled query teardown

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 #### BREAKING FOR TYPESCRIPT USERS
 - Feature: Enhanced typescript definitions to allow for more valid type checking of graphql HOC [PR #695](https://github.com/apollographql/react-apollo/pull/695)
 - Feature: Flow types: [PR #695](https://github.com/apollographql/react-apollo/pull/695)
-
+- Fix: Fix bug with sync re-renders and recyled queries [PR #740](https://github.com/apollographql/react-apollo/pull/740)
 
 ### 1.3.0
 - Feature: Support tree shaking and smaller (marginally) bundles via rollup [PR #691](https://github.com/apollographql/react-apollo/pull/691)

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "uglify-js": "^3.0.13"
   },
   "dependencies": {
-    "apollo-client": "^1.2.2",
+    "apollo-client": "^1.4.0",
     "graphql-anywhere": "^3.0.0",
     "graphql-tag": "^2.0.0",
     "hoist-non-react-statics": "^1.2.0",

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -262,14 +262,14 @@ export default function graphql<TResult = {}, TProps = {}, TChildProps = Default
 
       componentWillUnmount() {
         if (this.type === DocumentType.Query) {
+          // Unsubscribe from our query subscription.
+          this.unsubscribeFromQuery();
+
           // Recycle the query observable if there ever was one.
           if (this.queryObservable) {
             recycler.recycle(this.queryObservable);
             delete this.queryObservable;
           }
-
-          // Unsubscribe from our query subscription.
-          this.unsubscribeFromQuery();
         }
 
         if (this.type === DocumentType.Subscription) this.unsubscribeFromQuery();

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -262,6 +262,10 @@ export default function graphql<TResult = {}, TProps = {}, TChildProps = Default
 
       componentWillUnmount() {
         if (this.type === DocumentType.Query) {
+          // It is critical that this happens prior to recyling the query
+          // if not it breaks the loading state / network status because
+          // an orphan observer is created in AC (intended) which is cleaned up
+          // when the browser has time via a setTimeout(0)
           // Unsubscribe from our query subscription.
           this.unsubscribeFromQuery();
 

--- a/test/react-web/client/graphql/queries/errors.test.tsx
+++ b/test/react-web/client/graphql/queries/errors.test.tsx
@@ -247,7 +247,7 @@ describe('[queries] errors', () => {
       } finally {
         console.error = origError;
       }
-    }, 20);
+    }, 50);
   }));
 
   it('passes any cached data when there is a GraphQL error', (done) => {


### PR DESCRIPTION
Fix for #718, #667, and probably a lot of other loading issues by removing the current subscription before recycling the observable 

I'm going to add a test in the morning for this, but for all those impacted, this will be released tomorrow after the flow PR is released in AC. 👍 

TODO:
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
