### PR TITLE
Suggestion: Don't return last result, return actual cache data

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -622,7 +622,11 @@ export default function graphql<
             assign(data, this.previousData, currentResult.data);
           } else if (error) {
             // if there is error, use any previously cached data
-            assign(data, (this.queryObservable.getLastResult() || {}).data);
+            try {
+              assign(data, this.store.readQuery({ query: document, opts }));
+            } catch (exception) {
+              // raised if possibly no data. do nothing. 
+            }
           } else {
             assign(data, currentResult.data);
             this.previousData = currentResult.data;

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -625,7 +625,7 @@ export default function graphql<
             try {
               assign(data, this.client.readQuery({ query: document, variables: opts.variables }));
             } catch (exception) {
-              // raised if possibly no data. do nothing. 
+              // raised if possibly no data. do nothing.
             }
           } else {
             assign(data, currentResult.data);

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -623,7 +623,7 @@ export default function graphql<
           } else if (error) {
             // if there is error, use any previously cached data
             try {
-              assign(data, this.client.readQuery({ query: document, opts }));
+              assign(data, this.client.readQuery({ query: document, variables: opts.variables }));
             } catch (exception) {
               // raised if possibly no data. do nothing. 
             }

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -623,7 +623,7 @@ export default function graphql<
           } else if (error) {
             // if there is error, use any previously cached data
             try {
-              assign(data, this.store.readQuery({ query: document, opts }));
+              assign(data, this.client.readQuery({ query: document, opts }));
             } catch (exception) {
               // raised if possibly no data. do nothing. 
             }


### PR DESCRIPTION
This is a quick code change suggestion from #801. It brings the code more in line with what the actual comment says is the writer's intent. We will simply re-run the same query on the store, with fresh options.