### PR TITLE
fix typescript usage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,9 @@
 # Change log
 
 ### vNext
-- Fix: Fix issue around hoisting non react statics for RN
-- Fix: Fix issue where options was called even though skip was present
-- Improvement: Allow for better typescript usage with improved types
+- Fix: Fix issue around hoisting non react statics for RN [#859](https://github.com/apollographql/react-apollo/pull/859)
+- Fix: Fix issue where options was called even though skip was present [#859](https://github.com/apollographql/react-apollo/pull/859)
+- Improvement: Allow for better typescript usage with improved types [#862](https://github.com/apollographql/react-apollo/pull/862)
 
 ### 1.4.3
 - Feature: You can now supply a client in options object passed to the `graphql` high oder component. [PR #729](https://github.com/apollographql/react-apollo/pull/729)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### vNext
 - Fix: Fix issue around hoisting non react statics for RN
 - Fix: Fix issue where options was called even though skip was present
+- Improvement: Allow for better typescript usage with improved types
 
 ### 1.4.3
 - Feature: You can now supply a client in options object passed to the `graphql` high oder component. [PR #729](https://github.com/apollographql/react-apollo/pull/729)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Change log
 
 ### vNext
+
+### 1.4.4
 - Fix: Fix issue around hoisting non react statics for RN [#859](https://github.com/apollographql/react-apollo/pull/859)
 - Fix: Fix issue where options was called even though skip was present [#859](https://github.com/apollographql/react-apollo/pull/859)
 - Improvement: Allow for better typescript usage with improved types [#862](https://github.com/apollographql/react-apollo/pull/862)

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,4 @@
-import { danger, fail, warn, message } from 'danger';
+// Removed import
 import { includes } from 'lodash';
 import * as fs from 'fs';
 
@@ -17,8 +17,10 @@ const filesOnly = (file: string) =>
 
 // Custom subsets of known files
 const modifiedAppFiles = modified
-  .filter(p => includes(p, 'src/') || includes(p, 'test/'))
+  .filter(p => includes(p, 'src/'))
   .filter(p => filesOnly(p) && typescriptOnly(p));
+
+const modifiedTestFiles = modified.filter(p => includes(p, 'test/'));
 
 // Takes a list of file paths, and converts it into clickable links
 const linkableFiles = paths => {
@@ -70,10 +72,7 @@ if (pr.body.length === 0) {
 
 const hasAppChanges = modifiedAppFiles.length > 0;
 
-const testChanges = modifiedAppFiles.filter(filepath =>
-  filepath.includes('test'),
-);
-const hasTestChanges = testChanges.length > 0;
+const hasTestChanges = modifiedTestFiles.length > 0;
 
 // Warn when there is a big PR
 const bigPRThreshold = 500;
@@ -89,7 +88,7 @@ if (hasAppChanges && !hasTestChanges) {
 }
 
 // Be careful of leaving testing shortcuts in the codebase
-const onlyTestFiles = testChanges.filter(x => {
+const onlyTestFiles = modifiedTestFiles.filter(x => {
   const content = fs.readFileSync(x).toString();
   return (
     content.includes('it.only') ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "React data container for Apollo Client",
   "main": "lib/react-apollo.umd.js",
   "module": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-watch": "jest --watch",
     "posttest": "npm run lint",
     "filesize": "npm run compile:browser && bundlesize",
-    "flow-check": "flow check",
+    "type-check": "tsc ./test/typescript.ts --noEmit --jsx react --noEmitOnError --lib es6,dom --experimentalDecorators && flow check",
     "compile": "tsc",
     "bundle": "rollup -c && rollup -c rollup.browser.config.js && rollup -c rollup.test-utils.config.js && cp ./index.js.flow ./lib",
     "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/react-apollo.browser.umd.js --i graphql-tag --i react --i apollo-client -o=./dist/index.js && npm run minify:browser && npm run compress:browser",
@@ -52,7 +52,7 @@
     "npm",
     "react"
   ],
-  "author": "James Baxley <james.baxley@newspring.cc>",
+  "author": "James Baxley <james@meteor.com>",
   "babel": {
     "presets": [
       "react-native"
@@ -72,7 +72,8 @@
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/examples",
-      "<rootDir>/test/flow.js"
+      "<rootDir>/test/flow.js",
+      "<rootDir>/test/typescript.ts"
     ],
     "testRegex": "(/test/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "collectCoverage": true

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,14 +1,15 @@
 export { default as ApolloProvider } from './ApolloProvider';
-export {
-  default as graphql,
+export { default as graphql } from './graphql';
+import {
   MutationOpts,
   QueryOpts,
   QueryProps,
+  NamedProps,
   MutationFunc,
   OptionProps,
-  DefaultChildProps,
+  ChildProps,
   OperationOption,
-} from './graphql';
+} from './types';
 export { withApollo } from './withApollo';
 
 // expose easy way to join queries from redux

--- a/src/queryRecycler.ts
+++ b/src/queryRecycler.ts
@@ -1,0 +1,92 @@
+import { ObservableQuery, Subscription } from 'apollo-client';
+
+import { QueryOpts } from './types';
+
+/**
+ * An observable query recycler stores some observable queries that are no
+ * longer in use, but that we may someday use again.
+ *
+ * Recycling observable queries avoids a few unexpected functionalities that
+ * may be hit when using the `react-apollo` API. Namely not updating queries
+ * when a component unmounts, and calling reducers/`updateQueries` more times
+ * then is necessary for old observable queries.
+ *
+ * We assume that the GraphQL document for every `ObservableQuery` is the same.
+ *
+ * For more context on why this was added and links to the issues recycling
+ * `ObservableQuery`s fixes see issue [#462][1].
+ *
+ * [1]: https://github.com/apollographql/react-apollo/pull/462
+ */
+export class ObservableQueryRecycler {
+  /**
+   * The internal store for our observable queries and temporary subscriptions.
+   */
+  private observableQueries: Array<{
+    observableQuery: ObservableQuery<any>;
+    subscription: Subscription;
+  }> = [];
+
+  /**
+   * Recycles an observable query that the recycler is finished with. It is
+   * stored in this class so that it may be used later on.
+   *
+   * A subscription is made to the observable query so that it continues to
+   * live even though the updates are noops.
+   *
+   * By recycling an observable query we keep the results fresh so that when it
+   * gets reused all of the mutations that have happened since recycle and
+   * reuse have been applied.
+   */
+  public recycle(observableQuery: ObservableQuery<any>): void {
+    // Stop the query from polling when we recycle. Polling may resume when we
+    // reuse it and call `setOptions`.
+    observableQuery.setOptions({
+      fetchPolicy: 'standby',
+      pollInterval: 0,
+      fetchResults: false, // ensure we don't create another observer in AC
+    });
+
+    this.observableQueries.push({
+      observableQuery,
+      subscription: observableQuery.subscribe({}),
+    });
+  }
+
+  /**
+   * Reuses an observable query that was recycled earlier on in this class’s
+   * lifecycle. This observable was kept fresh by our recycler with a
+   * subscription that will be unsubscribed from before returning the
+   * observable query.
+   *
+   * All mutations that occured between the time of recycling and the time of
+   * reusing have been applied.
+   */
+  public reuse(options: QueryOpts): ObservableQuery<any> {
+    if (this.observableQueries.length <= 0) {
+      return null;
+    }
+    const { observableQuery, subscription } = this.observableQueries.pop();
+    subscription.unsubscribe();
+
+    // strip off react-apollo specific options
+    const { ssr, skip, client, ...modifiableOpts } = options;
+
+    // When we reuse an `ObservableQuery` then the document and component
+    // GraphQL display name should be the same. Only the options may be
+    // different.
+    //
+    // Therefore we need to set the new options.
+    //
+    // If this observable query used to poll then polling will be restarted.
+    observableQuery.setOptions({
+      ...modifiableOpts,
+      // Explicitly set options changed when recycling to make sure they
+      // are set to `undefined` if not provided in options.
+      pollInterval: options.pollInterval,
+      fetchPolicy: options.fetchPolicy,
+    });
+
+    return observableQuery;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,98 @@
+import { ComponentClass, StatelessComponent } from 'react';
+
+import ApolloClient, {
+  ObservableQuery,
+  MutationQueryReducersMap,
+  Subscription,
+  ApolloStore,
+  ApolloQueryResult,
+  ApolloError,
+  FetchPolicy,
+  FetchMoreOptions,
+  UpdateQueryOptions,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
+} from 'apollo-client';
+import { PureQueryOptions } from 'apollo-client/core/types';
+import { MutationUpdaterFn } from 'apollo-client/core/watchQueryOptions';
+
+import { ExecutionResult, DocumentNode } from 'graphql';
+
+export interface MutationOpts {
+  variables?: Object;
+  optimisticResponse?: Object;
+  updateQueries?: MutationQueryReducersMap;
+  refetchQueries?: string[] | PureQueryOptions[];
+  update?: MutationUpdaterFn;
+  client?: ApolloClient;
+}
+
+export interface QueryOpts {
+  ssr?: boolean;
+  variables?: { [key: string]: any };
+  fetchPolicy?: FetchPolicy;
+  pollInterval?: number;
+  client?: ApolloClient;
+  // deprecated
+  skip?: boolean;
+}
+
+export interface QueryProps {
+  error?: ApolloError;
+  networkStatus: number;
+  loading: boolean;
+  variables: {
+    [variable: string]: any;
+  };
+  fetchMore: (
+    fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions,
+  ) => Promise<ApolloQueryResult<any>>;
+  refetch: (variables?: any) => Promise<ApolloQueryResult<any>>;
+  startPolling: (pollInterval: number) => void;
+  stopPolling: () => void;
+  subscribeToMore: (options: SubscribeToMoreOptions) => () => void;
+  updateQuery: (
+    mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any,
+  ) => void;
+}
+
+export type MutationFunc<TResult> = (
+  opts: MutationOpts,
+) => Promise<ApolloQueryResult<TResult>>;
+
+export interface OptionProps<TProps, TResult> {
+  ownProps: TProps;
+  data?: QueryProps & TResult;
+  mutate?: MutationFunc<TResult>;
+}
+
+export type ChildProps<P, R> = P & {
+  data?: QueryProps & R;
+  mutate?: MutationFunc<R>;
+};
+
+export type NamedProps<P, R> = P & {
+  ownProps: R;
+};
+
+export interface OperationOption<TProps, TResult> {
+  options?:
+    | QueryOpts
+    | MutationOpts
+    | ((props: TProps) => QueryOpts | MutationOpts);
+  props?: (props: OptionProps<TProps, TResult>) => any;
+  skip?: boolean | ((props: any) => boolean);
+  name?: string;
+  withRef?: boolean;
+  shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean;
+  alias?: string;
+}
+
+export type CompositeComponent<P> = ComponentClass<P> | StatelessComponent<P>;
+
+export interface ComponentDecorator<TOwnProps, TMergedProps> {
+  (component: CompositeComponent<TMergedProps>): ComponentClass<TOwnProps>;
+}
+export interface InferableComponentDecorator<TOwnProps> {
+  <T extends CompositeComponent<TOwnProps>>(component: T): T;
+}

--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -31,7 +31,7 @@ import {
 } from 'graphql';
 
 import { parser, DocumentType } from './parser';
-import { OperationOption } from './graphql';
+import { OperationOption } from './types';
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,0 +1,57 @@
+// this file tests compliation of typescript types to ensure compatibility
+// we intentionly don't enfore TS compliation on the reset of the tests so we can
+// test things like improper arugment calling / etc to cause errors and ensure
+// that the are handled
+import * as React from 'react';
+import gql from 'graphql-tag';
+
+import { graphql } from '../src';
+import { ChildProps, NamedProps, QueryProps } from '../src/types';
+
+const historyQuery = gql`
+  query history($solutionId: String) {
+    history(solutionId: $solutionId) {
+      solutionId
+      delta
+    }
+  }
+`;
+
+type Data = {
+  history: Record<any, any>[];
+};
+
+type Props = {
+  solutionId: string;
+};
+
+// standard wrapping
+const withHistory = graphql<Data, Props>(historyQuery, {
+  options: ownProps => ({
+    variables: {
+      solutionId: ownProps.solutionId,
+    },
+  }),
+});
+
+class HistoryView extends React.Component<ChildProps<Props, Data>, {}> {}
+
+const HistoryViewWithData = withHistory(HistoryView);
+
+// decorator
+@graphql<Data, Props>(historyQuery)
+class DecoratedHistoryView extends React.Component<ChildProps<Props, Data>> {
+  render() {
+    return null;
+  }
+}
+
+// with using name
+const withHistoryUsingName = graphql<Data, Props>(historyQuery, {
+  name: 'organisationData',
+  props: ({
+    organisationData,
+  }: NamedProps<{ organisationData: QueryProps & Data }, Props>) => ({
+    ...organisationData,
+  }),
+});


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
fixes #786 
fixes #809,
fixes #810.

Special thanks to @alexzielenski for [the comment](https://github.com/apollographql/react-apollo/issues/786#issuecomment-309249584) which helped to inform some of these fixes.

Official usage docs will be coming soon, but in the meantime, here is a sample of how to use some of the improved types:

```js
import * as React from 'react';
import gql from 'graphql-tag';

import { graphql } from '../src';
import { ChildProps, NamedProps, QueryProps } from '../src/types';

const historyQuery = gql`
  query history($solutionId: String) {
    history(solutionId: $solutionId) {
      solutionId
      delta
    }
  }
`;

type Data = {
  history: Record<any, any>[];
};

type Props = {
  solutionId: string;
};

// standard wrapping
const withHistory = graphql<Data, Props>(historyQuery, {
  options: ownProps => ({
    variables: {
      solutionId: ownProps.solutionId,
    },
  }),
});

class HistoryView extends React.Component<ChildProps<Props, Data>, {}> {}

const HistoryViewWithData = withHistory(HistoryView);

// decorator
@graphql<Data, Props>(historyQuery)
class DecoratedHistoryView extends React.Component<ChildProps<Props, Data>> {
  render() {
    return null;
  }
}

// with using name
const withHistoryUsingName = graphql<Data, Props>(historyQuery, {
  name: 'organisationData',
  props: ({
    organisationData,
  }: NamedProps<{ organisationData: QueryProps & Data }, Props>) => ({
    ...organisationData,
  }),
});

```



### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
