### PR TITLE
chore(deps): Add timezone to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "pinVersions": true,
   "semanticCommits": true,
   "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
+  "timezone": "America/Los_Angeles",
   "schedule": ["after 10pm and before 5am on every weekday"],
   "rebaseStalePrs": true,
   "prCreation": "not-pending",


### PR DESCRIPTION
Renovate is currently configured to use the schedule "after 10pm and before 5am on every weekday" however without a configured "timezone" then these times will default to UTC. This PR adds the America/Los_Angeles IANA time zone to the `renovate.json` configuration file, assuming that's the preferred timezone for this schedule.

