### PR TITLE
fix exports

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### vNext
 
+### 1.4.10
+- Fix: fix UMD bundle pointing to apolloClient for some reason
+
 ### 1.4.9
 - Fix: fix matching types with exports for flow and ts
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "React data container for Apollo Client",
   "main": "lib/react-apollo.umd.js",
   "module": "./lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export * from './browser';
-export * from './server';
+export {
+  getDataFromTree,
+  renderToStringWithData,
+  walkTree,
+  cleanupApolloState,
+} from './server';

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -15,7 +15,7 @@ import {
   walkTree,
   getDataFromTree,
   renderToStringWithData,
-} from '../../../src/server';
+} from '../../../src';
 import 'isomorphic-fetch';
 import gql from 'graphql-tag';
 import * as _ from 'lodash';


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
For some reason (I'd love someone to help me understand!) the 1.4.9 version of this library had a malformed UMD bundle where `getDataFromTree` was written as `apolloClient.getDataFromTree`?!

This fixes that issue and is already released