### PR TITLE
fix flow typing for PureComponent

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -122,6 +122,7 @@ export interface OperationComponent<
     component:
       | StatelessComponent<TMergedProps>
       | Class<React$Component<any, TMergedProps, any>>,
+      | Class<React$PureComponent<any, TMergedProps, any>>,
   ): Class<React$Component<void, TOwnProps, void>>,
 }
 
@@ -134,6 +135,7 @@ declare export function withApollo<TProps>(
   component:
     | StatelessComponent<TProps & ApolloClient>
     | Class<React$Component<any, TProps & ApolloClient, any>>,
+    | Class<React$PureComponent<any, TMergedProps, any>>,
 ): Class<React$Component<void, TProps & ApolloClient, void>>;
 
 export interface IDocumentDefinition {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -135,7 +135,7 @@ declare export function withApollo<TProps>(
   component:
     | StatelessComponent<TProps & ApolloClient>
     | Class<React$Component<any, TProps & ApolloClient, any>>,
-    | Class<React$PureComponent<any, TMergedProps, any>>,
+    | Class<React$PureComponent<any, TProps & ApolloClient, any>>,
 ): Class<React$Component<void, TProps & ApolloClient, void>>;
 
 export interface IDocumentDefinition {


### PR DESCRIPTION
This PR adds a `React$PureComponent` type are return type.

This is fixes flow errors when wrapping a pure component.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
