### PR TITLE
MockNetworkInterface match mock requests regardless of variable order

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Change log
 
 ### vNext
+- MockNetworkInterface match mock requests regardless of variable order [#973](https://github.com/apollographql/react-apollo/pull/973)
 
 ### 1.4.11
 - Replace string refs with callback refs [#908](https://github.com/apollographql/react-apollo/pull/908)

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -258,9 +258,10 @@ export class MockSubscriptionNetworkInterface extends MockNetworkInterface
 
 function requestToKey(request: ParsedRequest): string {
   const queryString = request.query && print(request.query);
-  return JSON.stringify({
+  const requestKey = {
     variables: request.variables || {},
     debugName: request.debugName,
     query: queryString,
-  });
+  };
+  return JSON.stringify(requestKey, Object.keys(requestKey).sort());
 }


### PR DESCRIPTION
Currently mock data needs to exactly match the request being made within a component being tested. This is because requests object are [stringified](https://github.com/apollographql/react-apollo/blob/master/src/test-utils.tsx#L259-L266) and used as keys when [registering](https://github.com/apollographql/react-apollo/blob/master/src/test-utils.tsx#L121) and [looking up](https://github.com/apollographql/react-apollo/blob/master/src/test-utils.tsx#L138) the corresponding response objects to be returned. This change sorts the request object when it is stringified so the order of variables doesn't matter.

This issue is discussed in #674 
