### PR TITLE
Fix Redux `Store` flow errors

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -27,21 +27,21 @@ export { gql, compose };
 declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
 
 export interface ProviderProps {
-  store?: Store<any>,
+  store?: Store<*, *>,
   client: ApolloClient,
 }
 
 declare export class ApolloProvider extends React$Component {
   props: ProviderProps,
   childContextTypes: {
-    store: Store,
+    store: Store<*, *>,
     client: ApolloClient,
   },
   contextTypes: {
-    store: Store,
+    store: Store<*, *>,
   },
   getChildContext(): {
-    store: Store,
+    store: Store<*, *>,
     client: ApolloClient,
   },
   render(): React$Element<*>,
@@ -100,7 +100,7 @@ export interface OptionProps<TProps, TResult> {
 export type OptionDescription<P> = (props: P) => QueryOpts | MutationOpts;
 
 export type NamedProps<P, R> = P & {
-  ownProps: R;
+  ownProps: R,
 };
 
 export interface OperationOption<TProps: {}, TResult: {}> {
@@ -146,7 +146,7 @@ declare export function parser(document: DocumentNode): IDocumentDefinition;
 
 export interface Context {
   client?: ApolloClient,
-  store?: Store,
+  store?: Store<*, *>,
   [key: string]: any,
 }
 


### PR DESCRIPTION
## The fix
This should fix the Redux-related flowtype errors that are popping up in react-apollo due to incorrect usage of the Redux `Store` type in `index.js.flow`.

The error currently appears as:
```
node_modules/react-apollo/index.js.flow:30
 30:     store: Store,
                ^^^^^ Store. Application of polymorphic type needs <list of 2 arguments>. (Can use `*` for inferrable ones)
```

This fix is basically adding inferred types (`*`) as arguments to all references to the Redux `Store` type inside of `index.js.flow`. This should fix #898.

## Additional Details
Generally you want to pass in your State and Actions as arguments to `Store`. i.e.:
```javascript
type State = {
  // ...
}

type Actions = {
  // ...
}

const foo: Store<State, Actions> = // ...
```

... but seeing as how the usage of `Store` was incorrect to begin with, and in one area, there was a `Store<any>`, I figured this is a decent step forward in correctly typing this aspect of react-apollo. 

If perhaps this is not the right approach to fixing this flow error (i.e. maybe we want to somehow be more explicit about the Redux State and Action arguments, feel free to toss this PR out.

Cheers,

rich
