### PR TITLE
Added variables types with Typescript

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ### vNext
 - Added notifyOnNetworkStatusChange to QueryOpts and MutationOpts Typesccript definitions [#1034](https://github.com/apollographql/react-apollo/pull/1034)
+- Added variables types with Typescript [#997](https://github.com/apollographql/react-apollo/pull/997)
 
 ### 1.4.15
 - Fix: handle calling refetch in child componentDidMount

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,8 @@ import { MutationUpdaterFn } from 'apollo-client/core/watchQueryOptions';
 
 import { ExecutionResult, DocumentNode } from 'graphql';
 
-export interface MutationOpts {
-  variables?: Object;
+export interface MutationOpts<TVariables = OperationVariables> {
+  variables?: TVariables;
   optimisticResponse?: Object;
   updateQueries?: MutationQueryReducersMap;
   refetchQueries?: string[] | PureQueryOptions[];
@@ -28,9 +28,9 @@ export interface MutationOpts {
   notifyOnNetworkStatusChange?: boolean;
 }
 
-export interface QueryOpts {
+export interface QueryOpts<TVariables = OperationVariables> {
   ssr?: boolean;
-  variables?: { [key: string]: any };
+  variables?: TVariables;
   fetchPolicy?: FetchPolicy;
   pollInterval?: number;
   client?: ApolloClient;
@@ -39,17 +39,15 @@ export interface QueryOpts {
   skip?: boolean;
 }
 
-export interface QueryProps {
+export interface QueryProps<TVariables = OperationVariables> {
   error?: ApolloError;
   networkStatus: number;
   loading: boolean;
-  variables: {
-    [variable: string]: any;
-  };
+  variables: TVariables;
   fetchMore: (
     fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions,
   ) => Promise<ApolloQueryResult<any>>;
-  refetch: (variables?: any) => Promise<ApolloQueryResult<any>>;
+  refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>;
   startPolling: (pollInterval: number) => void;
   stopPolling: () => void;
   subscribeToMore: (options: SubscribeToMoreOptions) => () => void;
@@ -58,8 +56,8 @@ export interface QueryProps {
   ) => void;
 }
 
-export type MutationFunc<TResult> = (
-  opts: MutationOpts,
+export type MutationFunc<TResult, TVariables = OperationVariables> = (
+  opts: MutationOpts<TVariables>,
 ) => Promise<ApolloQueryResult<TResult>>;
 
 export interface OptionProps<TProps, TResult> {
@@ -75,6 +73,10 @@ export type ChildProps<P, R> = P & {
 
 export type NamedProps<P, R> = P & {
   ownProps: R;
+};
+
+export type OperationVariables = {
+  [key: string]: any;
 };
 
 export interface OperationOption<TProps, TResult> {

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -6,7 +6,7 @@ import * as React from 'react';
 import gql from 'graphql-tag';
 
 import { graphql } from '../src';
-import { ChildProps, NamedProps, QueryProps } from '../src';
+import { ChildProps, NamedProps, QueryProps, MutationFunc } from '../src';
 
 const historyQuery = gql`
   query history($solutionId: String) {
@@ -17,8 +17,30 @@ const historyQuery = gql`
   }
 `;
 
+const historyMutation = gql`
+  mutation updateHistory($input: updateHistoryMutation) {
+    updateHistory(input: $input) {
+      solutionId
+      delta
+    }
+  }
+`;
+
 type Data = {
   history: Record<any, any>[];
+};
+
+type Mutation = {
+  updateHistory?: MutationFunc<MutationPayload, MutationInput>;
+};
+
+type MutationPayload = {
+  updateHistory: Record<any, any>[];
+};
+
+type MutationInput = {
+  id: string;
+  newDelta: string;
 };
 
 type Props = {
@@ -55,3 +77,22 @@ const withHistoryUsingName = graphql<Data, Props>(historyQuery, {
     ...organisationData,
   }),
 });
+
+// mutation with name
+class UpdateHistoryView extends React.Component<
+  ChildProps<Props & Mutation, MutationPayload>,
+  {}
+> {
+  updateHistory() {
+    this.props.updateHistory({
+      variables: {
+        id: 'historyId',
+        newDelta: 'newDelta',
+      },
+    });
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -39,8 +39,10 @@ type MutationPayload = {
 };
 
 type MutationInput = {
-  id: string;
-  newDelta: string;
+  input: {
+    id: string;
+    newDelta: string;
+  };
 };
 
 type Props = {
@@ -86,8 +88,10 @@ class UpdateHistoryView extends React.Component<
   updateHistory() {
     this.props.updateHistory({
       variables: {
-        id: 'historyId',
-        newDelta: 'newDelta',
+        input: {
+          id: 'historyId',
+          newDelta: 'newDelta',
+        },
       },
     });
   }


### PR DESCRIPTION
Here is a small update on Typescript part, so we can type queries' & mutations' variables, as [apollo-codegen](https://github.com/apollographql/apollo-codegen) generates these types for us. Default values are used, so it shouldn't break any previous code.

I also added some tests to describe general usage.