### PR TITLE
Remove typenames from MockedProvider

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Feature: Support apollo-client 2.0
 - Fix: Scope query recyclers by client [#876](https://github.com/apollographql/react-apollo/pull/876)
 - MockNetworkInterface match mock requests regardless of variable order [#973](https://github.com/apollographql/react-apollo/pull/973)
+- Allow to pass removeTypenames to MockedProvider [#1001](https://github.com/apollographql/react-apollo/pull/1001)
 
 ### 1.4.12
 - Fix: fix issue with bad deploy

--- a/examples/base/src/__tests__/App.js
+++ b/examples/base/src/__tests__/App.js
@@ -133,6 +133,41 @@ describe('withCharacter', () => {
   });
 });
 
+describe('MocksWithoutTypename', () => {
+  it('reshapes the data into the passed props', done => {
+    const hero_without_typename = {
+      name: 'anakin',
+      id: '1',
+      friends: null,
+    };
+    const queryWithoutTypename = HERO_QUERY;
+
+    class Container extends React.Component<ShapedProps> {
+      componentWillReceiveProps(next: ShapedProps) {
+        expect(next.hero).toEqual(hero_without_typename);
+        done();
+      }
+      render() {
+        return null;
+      }
+    }
+
+    const ContainerWithData = withCharacter(Container);
+    const mocks = [
+      {
+        request: { query: queryWithoutTypename, variables },
+        result: { data: { hero: hero_without_typename } },
+      },
+    ];
+
+    renderer.create(
+      <MockedProvider mocks={mocks} removeTypename>
+        <ContainerWithData {...variables} />
+      </MockedProvider>,
+    );
+  });
+});
+
 describe('CharacterWithoutData', () => {
   it('handles a loading state', () => {
     const output = renderer.create(<CharacterWithoutData loading />);

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -20,8 +20,9 @@ export class MockedProvider extends React.Component<any, any> {
     super(props, context);
     if (this.props.client) return;
 
+    const addTypename = !this.props.removeTypename;
     const networkInterface = mockNetworkInterface.apply(null, this.props.mocks);
-    this.client = new ApolloClient({ networkInterface });
+    this.client = new ApolloClient({ networkInterface, addTypename });
   }
 
   render() {


### PR DESCRIPTION
This PR allows to pass a removeTypenames prop to the MockedProvider, this way there's no need to add the __typename field to the mocked data.

Right now, to add mocked data in tests, it's required to use `addTypenameToDocument` in all of the queries:

```
const query = addTypenameToDocument(HERO_QUERY);
```

Together with this, the mocked data needs to include the __typename field in all of the models:

```
export const hero_no_friends = {
  __typename: 'Droid',
  name: 'r2d2',
  id: '1',
  friends: null,
};
```

I find this a bit of a pain, and I would prefer not having to do this. As the apollo-client accepts an `addTypename` field, we can allow the MockedProvider to configure that option as we'd like.

This can be used this like this:

```
<MockedProvider mocks={mocks} removeTypename>
```

I didn't find any tests for test-utils, so I only added an example test within the base example.