### PR TITLE
Fix import of test-utils in example

### DIFF
--- a/examples/base/src/__tests__/App.js
+++ b/examples/base/src/__tests__/App.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
-// @IMPORTANT this is normally consumed from react-apollo/test-utils
-// but during development, it needs to be pulled from lib
-import { MockedProvider } from 'react-apollo/lib/test-utils';
+import { MockedProvider } from 'react-apollo/test-utils';
 
 import { addTypenameToDocument } from 'apollo-client';
 


### PR DESCRIPTION
See https://github.com/apollographql/react-apollo/issues/878

Makes example code match actual import usage of test-utils.