### PR TITLE
Added notifyOnNetworkStatusChange to QueryOpts and MutationOpts types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Change log
 
 ### vNext
-
+- Added notifyOnNetworkStatusChange to QueryOpts and MutationOpts Typesccript definitions [#1034](https://github.com/apollographql/react-apollo/pull/1034)
 
 ### 1.4.15
 - Fix: handle calling refetch in child componentDidMount

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,9 +34,9 @@ export interface QueryOpts {
   fetchPolicy?: FetchPolicy;
   pollInterval?: number;
   client?: ApolloClient;
+  notifyOnNetworkStatusChange?: boolean;
   // deprecated
   skip?: boolean;
-  notifyOnNetworkStatusChange?: boolean;
 }
 
 export interface QueryProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface MutationOpts {
   refetchQueries?: string[] | PureQueryOptions[];
   update?: MutationUpdaterFn;
   client?: ApolloClient;
+  notifyOnNetworkStatusChange?: boolean;
 }
 
 export interface QueryOpts {
@@ -35,6 +36,7 @@ export interface QueryOpts {
   client?: ApolloClient;
   // deprecated
   skip?: boolean;
+  notifyOnNetworkStatusChange?: boolean;
 }
 
 export interface QueryProps {


### PR DESCRIPTION
This small PR fixes issue #896 - notifyOnNetworkStatusChange were missing from Typescript definitions of query and mutation options.