### PR TITLE
Move graphql from devDependencies to dependencies to fix flow errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,21 @@
     "test-watch": "jest --watch",
     "posttest": "npm run lint && npm run type-check",
     "filesize": "npm run compile:browser && bundlesize",
-    "type-check": "tsc ./test/typescript.ts --noEmit --jsx react --noEmitOnError --lib es6,dom --experimentalDecorators && flow check",
+    "type-check":
+      "tsc ./test/typescript.ts --noEmit --jsx react --noEmitOnError --lib es6,dom --experimentalDecorators && flow check",
     "compile": "tsc",
-    "bundle": "rollup -c && rollup -c rollup.browser.config.js && rollup -c rollup.test-utils.config.js",
-    "compile:browser": "rm -rf ./dist && mkdir ./dist && browserify ./lib/react-apollo.browser.umd.js --i graphql-tag --i react --i apollo-client -o=./dist/index.js && npm run minify:browser && npm run compress:browser",
-    "minify:browser": "uglifyjs -c -m -o ./dist/index.min.js -- ./dist/index.js",
+    "bundle":
+      "rollup -c && rollup -c rollup.browser.config.js && rollup -c rollup.test-utils.config.js",
+    "compile:browser":
+      "rm -rf ./dist && mkdir ./dist && browserify ./lib/react-apollo.browser.umd.js --i graphql-tag --i react --i apollo-client -o=./dist/index.js && npm run minify:browser && npm run compress:browser",
+    "minify:browser":
+      "uglifyjs -c -m -o ./dist/index.min.js -- ./dist/index.js",
     "compress:browser": "./scripts/gzip.js --file=./dist/index.min.js",
     "watch": "tsc -w",
     "lint": "tslint 'src/*.ts*' && tslint 'test/*.ts*'",
     "lint-staged": "lint-staged",
-    "lint-fix": "prettier --trailing-comma all --single-quote --write \"{src,test}/**/*.ts*\"",
+    "lint-fix":
+      "prettier --trailing-comma all --single-quote --write \"{src,test}/**/*.ts*\"",
     "postcompile": "npm run bundle",
     "prepublish": "npm run compile"
   },
@@ -105,7 +110,6 @@
     "enzyme": "2.9.1",
     "enzyme-to-json": "1.5.1",
     "flow-bin": "0.52.0",
-    "graphql": "0.10.5",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "jest": "20.0.4",
@@ -148,6 +152,7 @@
     "invariant": "^2.2.1",
     "lodash.pick": "^4.4.0",
     "object-assign": "^4.0.1",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "graphql": "0.10.5"
   }
 }


### PR DESCRIPTION
Since graphql flow types are imported in index.js.flow, flow expects the graphql package to be listed as a dependency instead of a devDependency. 

I've noticed the diff is quite large, I suspect a beautifier has changed the file as part of the pre-commit hook.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
