### PR TITLE
Do not update query after changing ApiClient

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,11 +3,12 @@
 ### vNext
 
 ### 1.4.16
-- upgrade to react-16 
+- upgrade to react-16
 - fix shallowEqual bug.
 - Added notifyOnNetworkStatusChange to QueryOpts and MutationOpts Typesccript definitions [#1034](https://github.com/apollographql/react-apollo/pull/1034)
 - Added variables types with Typescript [#997](https://github.com/apollographql/react-apollo/pull/997)
 - Made `ChildProps.data` non-optional [#1143](https://github.com/apollographql/react-apollo/pull/1143)
+- Fix: ensure `client` option can be used with mutation query [#1145](https://github.com/apollographql/react-apollo/pull/1145)
 
 ### 1.4.15
 - Fix: handle calling refetch in child componentDidMount

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -163,7 +163,10 @@ export default function graphql<
           // call any stacked refetch functions
           if (this.refetcherQueue) {
             const { args, resolve, reject } = this.refetcherQueue;
-            this.queryObservable.refetch(args).then(resolve).catch(reject);
+            this.queryObservable
+              .refetch(args)
+              .then(resolve)
+              .catch(reject);
           }
         }
       }
@@ -178,6 +181,10 @@ export default function graphql<
         }
 
         this.shouldRerender = true;
+
+        if (this.type === DocumentType.Mutation) {
+          return;
+        }
 
         if (this.client !== client && this.client !== nextContext.client) {
           if (client) {
@@ -195,9 +202,7 @@ export default function graphql<
           }
           return;
         }
-        if (this.type === DocumentType.Mutation) {
-          return;
-        }
+
         if (
           this.type === DocumentType.Subscription &&
           operationOptions.shouldResubscribe &&
@@ -209,6 +214,7 @@ export default function graphql<
           this.subscribeToQuery();
           return;
         }
+
         if (this.shouldSkip(nextProps)) {
           if (!this.shouldSkip(this.props)) {
             // if this has changed, we better unsubscribe


### PR DESCRIPTION
Using another ApiClient with graphql container and mutation causes running of `this.updateQuery(nextProps);` which should not be executed for mutation from my understanding. 

Fixes already closed #812. 
