### PR TITLE
Fixes issue with network-only and cache-and-network fetchPolicy being changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "colors": "1.1.2",
     "danger": "1.2.0",
     "enzyme": "3.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
     "enzyme-to-json": "1.6.0",
     "flow-bin": "0.52.0",
     "graphql": "0.11.4",
@@ -149,7 +150,6 @@
   },
   "dependencies": {
     "apollo-client": "^1.4.0",
-    "enzyme-adapter-react-16": "^1.0.0",
     "graphql-tag": "^2.0.0",
     "hoist-non-react-statics": "^2.2.0",
     "invariant": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "enzyme": "3.0.0",
     "enzyme-adapter-react-16": "1.0.0",
     "enzyme-to-json": "1.6.0",
-    "flow-bin": "0.52.0",
+    "flow-bin": "0.56.0",
     "graphql": "0.11.4",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "colors": "1.1.2",
     "danger": "1.2.0",
     "enzyme": "3.0.0",
-    "enzyme-adapter-react-16": "^1.0.0",
+    "enzyme-adapter-react-16": "1.0.0",
     "enzyme-to-json": "1.6.0",
     "flow-bin": "0.52.0",
     "graphql": "0.11.4",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lodash": "4.17.4",
     "minimist": "1.2.0",
     "mobx": "3.3.0",
-    "mobx-react": "4.3.2",
+    "mobx-react": "4.3.3",
     "pre-commit": "1.2.2",
     "prettier": "1.7.2",
     "pretty-bytes": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "enzyme-adapter-react-16": "1.0.0",
     "enzyme-to-json": "1.6.0",
     "flow-bin": "0.56.0",
-    "graphql": "0.11.4",
+    "graphql": "0.11.5",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "jest": "20.0.4",

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -414,12 +414,6 @@ export default function graphql<
 
         const opts = this.calculateOptions() as any;
         if (opts.ssr === false) return false;
-        if (
-          opts.fetchPolicy === 'network-only' ||
-          opts.fetchPolicy === 'cache-and-network'
-        ) {
-          opts.fetchPolicy = 'cache-first'; // ignore force fetch in SSR;
-        }
 
         const observable = this.getClient(this.props).watchQuery(
           assign({ query: document }, opts),


### PR DESCRIPTION
I mostly want to open this PR for the sake of conversation.  I can't for the life of me figure out why this logic exists inside of react-apollo, and it seems to be causing issues for many users as pointed out in #556.

I'm interested in some feedback, as I have not been using apollo for long, and it's not clear to me why the desired `fetchPolicy` would be changed despite what the developer intends.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.