### PR TITLE
Make OptionProps.data's TResult partial

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,11 @@
 
 ### vNext
 
+- Made `OptionProps.data`'s `TResult` partial [#1231](https://github.com/apollographql/react-apollo/pull/1231)
+
+
 ### 1.4.16
-- upgrade to react-16 
+- upgrade to react-16
 - fix shallowEqual bug.
 - Added notifyOnNetworkStatusChange to QueryOpts and MutationOpts Typesccript definitions [#1034](https://github.com/apollographql/react-apollo/pull/1034)
 - Added variables types with Typescript [#997](https://github.com/apollographql/react-apollo/pull/997)

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type MutationFunc<TResult, TVariables = OperationVariables> = (
 
 export interface OptionProps<TProps, TResult> {
   ownProps: TProps;
-  data?: QueryProps & TResult;
+  data?: QueryProps & Partial<TResult>;
   mutate?: MutationFunc<TResult>;
 }
 


### PR DESCRIPTION
This is a companion PR for https://github.com/apollographql/react-apollo/pull/1143, which made the result fields partial in `ChildProps`. The same was needed in `OptionProps`, so I added it here.