### PR TITLE
[WIP] feat(data): added writeQuery to props.data

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@types/redux-form": "7.0.5",
     "@types/redux-immutable": "3.0.37",
     "@types/sinon": "2.3.5",
+    "apollo-cache": "0.0.2",
     "apollo-cache-inmemory": "^0.2.0-beta.3",
     "apollo-client": "^2.0.0-beta.3",
     "babel-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@types/redux-form": "7.0.5",
     "@types/redux-immutable": "3.0.37",
     "@types/sinon": "2.3.5",
-    "apollo-cache": "0.0.2",
+    "apollo-cache": "0.2.0-rc.0",
     "apollo-cache-inmemory": "^0.2.0-beta.3",
     "apollo-client": "^2.0.0-beta.3",
     "babel-jest": "20.0.3",

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -522,7 +522,11 @@ export default function graphql<
         }
 
         const opts = this.calculateOptions(this.props);
-        const data = {};
+        const client = this.getClient(this.props);
+        const data = {
+          writeQuery: client.writeQuery.bind(client),
+        };
+
         assign(data, observableQueryFields(this.queryObservable));
 
         if (this.type === DocumentType.Subscription) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import ApolloClient, {
   PureQueryOptions,
   MutationUpdaterFn,
 } from 'apollo-client';
+import { DataProxy } from 'apollo-cache';
 // import { PureQueryOptions } from 'apollo-client/core/types';
 // import { MutationUpdaterFn } from 'apollo-client/core/watchQueryOptions';
 
@@ -51,6 +52,7 @@ export interface QueryProps<TVariables = OperationVariables> {
   updateQuery: (
     mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any,
   ) => void;
+  writeQuery: (options: DataProxy.WriteQueryOptions) => void;
 }
 
 export type MutationFunc<TResult, TVariables = OperationVariables> = (

--- a/test/react-web/client/graphql/queries/writeQuery.test.tsx
+++ b/test/react-web/client/graphql/queries/writeQuery.test.tsx
@@ -132,7 +132,6 @@ describe('[queries] writeQuery', () => {
       componentWillReceiveProps(props) {
         // tslint:disable-line
         if (!props.loading) {
-          console.log(props.data);
           expect(props.data.todo).toEqual(data.todo);
         }
         done();

--- a/test/react-web/client/graphql/queries/writeQuery.test.tsx
+++ b/test/react-web/client/graphql/queries/writeQuery.test.tsx
@@ -1,0 +1,152 @@
+/// <reference types="jest" />
+
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import gql from 'graphql-tag';
+import ApolloClient, { ApolloError, ObservableQuery } from 'apollo-client';
+import Cache from 'apollo-cache-inmemory';
+
+import { mockSingleLink } from '../../../../../src/test-utils';
+import { ApolloProvider, graphql } from '../../../../../src';
+
+describe('[queries] writeQuery', () => {
+  it('exposes writeQuery as part of the props api', done => {
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+    const data = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
+    const link = mockSingleLink({
+      request: { query },
+      result: { data },
+    });
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    @graphql(query, { options: { fetchPolicy: 'cache-only' } })
+    class Container extends React.Component<any, any> {
+      componentWillReceiveProps({ data }) {
+        // tslint:disable-line
+        expect(data.writeQuery).toBeTruthy();
+        expect(data.writeQuery instanceof Function).toBe(true);
+
+        try {
+          data.writeQuery({ query, data });
+          done();
+        } catch (err) {
+          // fail
+        }
+        done();
+      }
+      render() {
+        return null;
+      }
+    }
+
+    renderer.create(
+      <ApolloProvider client={client}>
+        <Container />
+      </ApolloProvider>,
+    );
+  });
+
+  it('exposes writeQuery as part of the props api during componentWillMount', done => {
+    const query = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+    const data = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
+    const link = mockSingleLink({ request: { query }, result: { data } });
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    @graphql(query, { options: { fetchPolicy: 'cache-only' } })
+    class Container extends React.Component<any, any> {
+      componentWillMount() {
+        // tslint:disable-line
+        expect(this.props.data.writeQuery).toBeTruthy();
+        expect(this.props.data.writeQuery instanceof Function).toBe(true);
+        done();
+      }
+      render() {
+        return null;
+      }
+    }
+
+    renderer.create(
+      <ApolloProvider client={client}>
+        <Container />
+      </ApolloProvider>,
+    );
+  });
+
+  it('writeQuery properly writes the query to the cache', done => {
+    const query = gql`
+      {
+        todo(id: 2) {
+          name
+        }
+      }
+    `;
+
+    const data = { todo: { name: 'write more tests' } };
+    const link = mockSingleLink({ request: { query }, result: { data } });
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    @graphql(query, { options: { fetchPolicy: 'cache-only' } })
+    class QueryWriter extends React.Component<any, any> {
+      componentDidMount() {
+        // tslint:disable-line
+        const { data } = this.props;
+        try {
+          data.writeQuery({ query, data });
+        } catch (err) {
+          // fail
+        }
+      }
+      render() {
+        return <QueryReader />;
+      }
+    }
+
+    @graphql(query, { options: { fetchPolicy: 'cache-only' } })
+    class QueryReader extends React.Component<any, any> {
+      componentWillReceiveProps(props) {
+        // tslint:disable-line
+        if (!props.loading) {
+          console.log(props.data);
+          expect(props.data.todo).toEqual(data.todo);
+        }
+        done();
+        return;
+      }
+      render() {
+        return null;
+      }
+    }
+
+    renderer.create(
+      <ApolloProvider client={client}>
+        <QueryWriter />
+      </ApolloProvider>,
+    );
+  });
+});


### PR DESCRIPTION
First step toward local state management with `graphql()`!

One of the tests isn't passing, for some reason it isn't writing properly to the cache. I'll try debugging tomorrow. We're also getting the same warning for the first test.

<details>
<summary>Console warnings</summary>

```
    console.warn node_modules/apollo-cache-inmemory/lib/writeToStore.js:114
      Missing field allPeople in {
        "variables": {},
        "loading": false,
        "networkStatus": 7
      }
    console.warn node_modules/apollo-cache-inmemory/lib/writeToStore.js:114
      Missing field todo in {
        "variables": {},
        "loading": false,
        "networkStatus": 7
      }
```

</details>