### PR TITLE
chore(flow): update flow types to flow-bin@0.56 semantics

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -24,27 +24,24 @@ import gql from 'graphql-tag';
 export * from 'apollo-client';
 export { gql, compose };
 
-declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
-
 export interface ProviderProps {
-  store?: Store<*, *>,
-  client: ApolloClient,
+  store?: Store<*, *>;
+  client: ApolloClient;
 }
 
-declare export class ApolloProvider extends React$Component {
-  props: ProviderProps,
+declare export class ApolloProvider extends React$Component<ProviderProps> {
   childContextTypes: {
     store: Store<*, *>,
     client: ApolloClient,
-  },
+  };
   contextTypes: {
     store: Store<*, *>,
-  },
+  };
   getChildContext(): {
     store: Store<*, *>,
     client: ApolloClient,
-  },
-  render(): React$Element<*>,
+  };
+  render(): React$Element<*>;
 }
 export type MutationFunc<TResult> = (
   opts: MutationOpts,
@@ -59,42 +56,42 @@ export type ChildProps<P, R> = {
 export type DefaultChildProps<P, R> = ChildProps<P, R>;
 
 export interface MutationOpts {
-  variables?: Object,
-  optimisticResponse?: Object,
-  updateQueries?: MutationQueryReducersMap<*>,
-  refetchQueries?: string[] | PureQueryOptions[],
-  update?: MutationUpdaterFn<*>,
+  variables?: Object;
+  optimisticResponse?: Object;
+  updateQueries?: MutationQueryReducersMap<*>;
+  refetchQueries?: string[] | PureQueryOptions[];
+  update?: MutationUpdaterFn<*>;
 }
 
 export interface QueryOpts {
-  ssr?: boolean,
-  variables?: Object,
-  fetchPolicy?: FetchPolicy,
-  pollInterval?: number,
-  skip?: boolean,
+  ssr?: boolean;
+  variables?: Object;
+  fetchPolicy?: FetchPolicy;
+  pollInterval?: number;
+  skip?: boolean;
 }
 
 export interface QueryProps {
-  error?: ApolloError,
-  networkStatus: number,
-  loading: boolean,
-  variables: Object,
+  error?: ApolloError;
+  networkStatus: number;
+  loading: boolean;
+  variables: Object;
   fetchMore: (
     fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions,
-  ) => Promise<ApolloQueryResult<any>>,
-  refetch: (variables?: Object) => Promise<ApolloQueryResult<any>>,
-  startPolling: (pollInterval: number) => void,
-  stopPolling: () => void,
-  subscribeToMore: (options: SubscribeToMoreOptions) => () => void,
+  ) => Promise<ApolloQueryResult<any>>;
+  refetch: (variables?: Object) => Promise<ApolloQueryResult<any>>;
+  startPolling: (pollInterval: number) => void;
+  stopPolling: () => void;
+  subscribeToMore: (options: SubscribeToMoreOptions) => () => void;
   updateQuery: (
     mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any,
-  ) => void,
+  ) => void;
 }
 
 export interface OptionProps<TProps, TResult> {
-  ownProps: TProps,
-  data: QueryProps & TResult,
-  mutate: MutationFunc<TResult>,
+  ownProps: TProps;
+  data: QueryProps & TResult;
+  mutate: MutationFunc<TResult>;
 }
 
 export type OptionDescription<P> = (props: P) => QueryOpts | MutationOpts;
@@ -104,13 +101,13 @@ export type NamedProps<P, R> = P & {
 };
 
 export interface OperationOption<TProps: {}, TResult: {}> {
-  options?: OptionDescription<TProps>,
-  props?: (props: OptionProps<TProps, TResult>) => any,
-  +skip?: boolean | ((props: any) => boolean),
-  name?: string,
-  withRef?: boolean,
-  shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean,
-  alias?: string,
+  options?: OptionDescription<TProps>;
+  props?: (props: OptionProps<TProps, TResult>) => any;
+  +skip?: boolean | ((props: any) => boolean);
+  name?: string;
+  withRef?: boolean;
+  shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean;
+  alias?: string;
 }
 
 export interface OperationComponent<
@@ -118,11 +115,7 @@ export interface OperationComponent<
   TOwnProps: Object = {},
   TMergedProps = ChildProps<TOwnProps, TResult>,
 > {
-  (
-    component:
-      | StatelessComponent<TMergedProps>
-      | Class<React$Component<any, TMergedProps, any>>,
-  ): Class<React$Component<void, TOwnProps, void>>,
+  (component: React$ComponentType<TOwnProps>): React$ComponentType<TOwnProps>;
 }
 
 declare export function graphql<TResult, TProps, TChildProps>(
@@ -131,34 +124,32 @@ declare export function graphql<TResult, TProps, TChildProps>(
 ): OperationComponent<TResult, TProps, TChildProps>;
 
 declare export function withApollo<TProps>(
-  component:
-    | StatelessComponent<TProps & ApolloClient>
-    | Class<React$Component<any, TProps & ApolloClient, any>>,
-): Class<React$Component<void, TProps & ApolloClient, void>>;
+  component: React$ComponentType<TProps & ApolloClient>,
+): React$ComponentType<TProps & ApolloClient>;
 
 export interface IDocumentDefinition {
-  type: DocumentType,
-  name: string,
-  variables: VariableDefinitionNode[],
+  type: DocumentType;
+  name: string;
+  variables: VariableDefinitionNode[];
 }
 
 declare export function parser(document: DocumentNode): IDocumentDefinition;
 
 export interface Context {
-  client?: ApolloClient,
-  store?: Store<*, *>,
-  [key: string]: any,
+  client?: ApolloClient;
+  store?: Store<*, *>;
+  [key: string]: any;
 }
 
 export interface QueryTreeArgument {
-  rootElement: React$Element<*>,
-  rootContext?: Context,
+  rootElement: React$Element<*>;
+  rootContext?: Context;
 }
 
 export interface QueryResult {
-  query: Promise<ApolloQueryResult<mixed>>,
-  element: React$Element<*>,
-  context: Context,
+  query: Promise<ApolloQueryResult<mixed>>;
+  element: React$Element<*>;
+  context: Context;
 }
 
 declare export function walkTree(

--- a/test/flow.js
+++ b/test/flow.js
@@ -10,7 +10,7 @@
 */
 
 // @flow
-import { Component } from 'react';
+import React, { Component } from 'react';
 import {
   withApollo,
   compose,
@@ -102,7 +102,7 @@ export default withCharacter(({ loading, hero, error }) => {
   return null;
 });
 
-export class Character extends Component {
+export class Character extends Component<*> {
   render() {
     const { loading, hero, error } = this.props;
     if (loading) return <div>Loading</div>;


### PR DESCRIPTION
I saw that this PR: https://github.com/apollographql/react-apollo/pull/1126 is not being merged since its waiting on changes in apollo-client.

However, by updating the types to use the new React component typing semantics, I seem to be able to use these types properly.

Assuming this covers what's needed to upgrade (It's possible I could be missing something), this closes #1220 and closes #1105.

If there's more that needs to be updated, I'd be happy to look into updating those areas as well.

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes) **(N/A)**
- [x] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion. **(N/A)**
