### PR TITLE
Support passing updater function to `setState` in SSR mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Fix: ensure `client` option can be used with mutation query [#1145](https://github.com/apollographql/react-apollo/pull/1145)
 
 - Made `OptionProps.data`'s `TResult` partial [#1231](https://github.com/apollographql/react-apollo/pull/1231)
-- Support passing callback to `setState` in SSR mode [#1263](https://github.com/apollographql/react-apollo/pull/1263)
+- Support passing an updater function to `setState` in SSR mode [#1263](https://github.com/apollographql/react-apollo/pull/1263)
 
 
 ### 1.4.16

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Fix: ensure `client` option can be used with mutation query [#1145](https://github.com/apollographql/react-apollo/pull/1145)
 
 - Made `OptionProps.data`'s `TResult` partial [#1231](https://github.com/apollographql/react-apollo/pull/1231)
+- Support passing callback to `setState` in SSR mode [#1263](https://github.com/apollographql/react-apollo/pull/1263)
 
 
 ### 1.4.16

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ export function walkTree(
       //   componentWillMount, which happens *before* render).
       instance.setState = newState => {
         if (typeof newState === 'function') {
-          newState = newState(instance.state);
+          newState = newState(instance.state, instance.props, instance.context);
         }
         instance.state = assign({}, instance.state, newState);
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,9 @@ export function walkTree(
       //   however, we don't need to re-render as well only support setState in
       //   componentWillMount, which happens *before* render).
       instance.setState = newState => {
+        if (typeof newState === 'function') {
+          newState = newState(instance.state);
+        }
         instance.state = assign({}, instance.state, newState);
       };
 

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -615,7 +615,7 @@ describe('SSR', () => {
         .catch(console.error);
     });
 
-    it('should allow for setting state in a component', done => {
+    it('should allow for setting state via an updater function', done => {
       const query = gql`
         query user($id: ID) {
           currentUser(id: $id) {
@@ -637,15 +637,25 @@ describe('SSR', () => {
 
       @graphql(query, { name: 'user' })
       class Element extends React.Component<any, any> {
-        state = { thing: 1 };
+        state = {
+          thing: 1,
+          userId: null,
+          client: null,
+        };
 
         componentWillMount() {
-          this.setState(state => ({ thing: state.thing + 1 }));
+          this.setState((state, props, context) => ({
+            thing: state.thing + 1,
+            userId: props.id,
+            client: context.client,
+          }));
         }
 
         render() {
-          const { user } = this.props;
+          const { user, id } = this.props;
           expect(this.state.thing).toBe(2);
+          expect(this.state.userId).toBe(id);
+          expect(this.state.client).toBe(apolloClient);
           return (
             <div>{user.loading ? 'loading' : user.currentUser.firstName}</div>
           );

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -66,11 +66,7 @@ describe('SSR', () => {
 
       it('basic element trees with nulls', () => {
         let elementCount = 0;
-        const rootElement = (
-          <div>
-            {null}
-          </div>
-        );
+        const rootElement = <div>{null}</div>;
         walkTree(rootElement, {}, element => {
           elementCount += 1;
         });
@@ -79,10 +75,9 @@ describe('SSR', () => {
 
       it('functional stateless components', () => {
         let elementCount = 0;
-        const MyComponent = ({ n }) =>
-          <div>
-            {_.times(n, i => <span key={i} />)}
-          </div>;
+        const MyComponent = ({ n }) => (
+          <div>{_.times(n, i => <span key={i} />)}</div>
+        );
         walkTree(<MyComponent n={5} />, {}, element => {
           elementCount += 1;
         });
@@ -91,11 +86,12 @@ describe('SSR', () => {
 
       it('functional stateless components with children', () => {
         let elementCount = 0;
-        const MyComponent = ({ n, children = null }) =>
+        const MyComponent = ({ n, children = null }) => (
           <div>
             {_.times(n, i => <span key={i} />)}
             {children}
-          </div>;
+          </div>
+        );
         walkTree(
           <MyComponent n={5}>
             <span>Foo</span>
@@ -110,20 +106,15 @@ describe('SSR', () => {
 
       it('functional stateless components with null children', () => {
         let elementCount = 0;
-        const MyComponent = ({ n, children = null }) =>
+        const MyComponent = ({ n, children = null }) => (
           <div>
             {_.times(n, i => <span key={i} />)}
             {children}
-          </div>;
-        walkTree(
-          <MyComponent n={5}>
-            {null}
-          </MyComponent>,
-          {},
-          element => {
-            elementCount += 1;
-          },
+          </div>
         );
+        walkTree(<MyComponent n={5}>{null}</MyComponent>, {}, element => {
+          elementCount += 1;
+        });
         expect(elementCount).toEqual(7);
       });
 
@@ -140,11 +131,7 @@ describe('SSR', () => {
         let elementCount = 0;
         class MyComponent extends React.Component<any, any> {
           render() {
-            return (
-              <div>
-                {_.times(this.props.n, i => <span key={i} />)}
-              </div>
-            );
+            return <div>{_.times(this.props.n, i => <span key={i} />)}</div>;
           }
         }
         walkTree(<MyComponent n={5} />, {}, element => {
@@ -173,11 +160,7 @@ describe('SSR', () => {
             super(); // note doesn't pass props or context
           }
           render() {
-            return (
-              <div>
-                {_.times(this.props.n, i => <span key={i} />)}
-              </div>
-            );
+            return <div>{_.times(this.props.n, i => <span key={i} />)}</div>;
           }
         }
         walkTree(<MyComponent n={5} />, {}, element => {
@@ -232,11 +215,9 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const WrappedElement = graphql(query)(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>,
-      );
+      const WrappedElement = graphql(query)(({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -271,11 +252,9 @@ describe('SSR', () => {
 
       const WrappedElement = graphql(query, {
         options: { fetchPolicy: 'network-only' },
-      })(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>,
-      );
+      })(({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -310,11 +289,9 @@ describe('SSR', () => {
 
       const WrappedElement = graphql(query, {
         options: { fetchPolicy: 'cache-and-network' },
-      })(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>,
-      );
+      })(({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -347,19 +324,18 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const WrappedElement = graphql(query)(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>,
-      );
+      const WrappedElement = graphql(query)(({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      ));
 
-      const Page = () =>
+      const Page = () => (
         <div>
           <span>Hi</span>
           <div>
             <WrappedElement />
           </div>
-        </div>;
+        </div>
+      );
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -409,10 +385,9 @@ describe('SSR', () => {
         skip: ({ data: { loading } }) => loading,
         options: ({ data }) => ({ variables: { id: data.currentUser.id } }),
       });
-      const Component = ({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.user.firstName}
-        </div>;
+      const Component = ({ data }) => (
+        <div>{data.loading ? 'loading' : data.user.firstName}</div>
+      );
       const WrappedComponent = withId(withUser(Component));
 
       const app = (
@@ -448,11 +423,7 @@ describe('SSR', () => {
 
       const WrappedElement = graphql(query, {
         options: { skip: true },
-      })(({ data }) =>
-        <div>
-          {data ? 'loading' : 'skipped'}
-        </div>,
-      );
+      })(({ data }) => <div>{data ? 'loading' : 'skipped'}</div>);
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -484,19 +455,18 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const WrappedElement = graphql(query)(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.error}
-        </div>,
-      );
+      const WrappedElement = graphql(query)(({ data }) => (
+        <div>{data.loading ? 'loading' : data.error}</div>
+      ));
 
-      const Page = () =>
+      const Page = () => (
         <div>
           <span>Hi</span>
           <div>
             <WrappedElement />
           </div>
-        </div>;
+        </div>
+      );
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -535,11 +505,9 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const WrappedElement = graphql(query, { skip: true })(({ data }) =>
-        <div>
-          {!data ? 'skipped' : 'dang'}
-        </div>,
-      );
+      const WrappedElement = graphql(query, { skip: true })(({ data }) => (
+        <div>{!data ? 'skipped' : 'dang'}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -573,11 +541,9 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const Element = graphql(query, { name: 'user' })(({ user }) =>
-        <div>
-          {user.loading ? 'loading' : user.currentUser.firstName}
-        </div>,
-      );
+      const Element = graphql(query, { name: 'user' })(({ user }) => (
+        <div>{user.loading ? 'loading' : user.currentUser.firstName}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -626,9 +592,62 @@ describe('SSR', () => {
           const { user } = this.props;
           expect(this.state.thing).toBe(2);
           return (
-            <div>
-              {user.loading ? 'loading' : user.currentUser.firstName}
-            </div>
+            <div>{user.loading ? 'loading' : user.currentUser.firstName}</div>
+          );
+        }
+      }
+
+      const app = (
+        <ApolloProvider client={apolloClient}>
+          <Element id={1} />
+        </ApolloProvider>
+      );
+
+      getDataFromTree(app)
+        .then(() => {
+          const initialState = apolloClient.store.getState();
+          expect(initialState.apollo.data).toBeTruthy();
+          expect(
+            initialState.apollo.data['$ROOT_QUERY.currentUser({"id":1})'],
+          ).toBeTruthy();
+          done();
+        })
+        .catch(console.error);
+    });
+
+    it('should allow for setting state in a component', done => {
+      const query = gql`
+        query user($id: ID) {
+          currentUser(id: $id) {
+            firstName
+          }
+        }
+      `;
+      const data = { currentUser: { firstName: 'James' } };
+      const variables = { id: 1 };
+      const networkInterface = mockNetworkInterface({
+        request: { query, variables },
+        result: { data },
+        delay: 50,
+      });
+      const apolloClient = new ApolloClient({
+        networkInterface,
+        addTypename: false,
+      });
+
+      @graphql(query, { name: 'user' })
+      class Element extends React.Component<any, any> {
+        state = { thing: 1 };
+
+        componentWillMount() {
+          this.setState(state => ({ thing: state.thing + 1 }));
+        }
+
+        render() {
+          const { user } = this.props;
+          expect(this.state.thing).toBe(2);
+          return (
+            <div>{user.loading ? 'loading' : user.currentUser.firstName}</div>
           );
         }
       }
@@ -674,11 +693,9 @@ describe('SSR', () => {
       const Element = graphql(query, {
         name: 'user',
         options: props => ({ variables: props, ssr: false }),
-      })(({ user }) =>
-        <div>
-          {user.loading ? 'loading' : user.currentUser.firstName}
-        </div>,
-      );
+      })(({ user }) => (
+        <div>{user.loading ? 'loading' : user.currentUser.firstName}</div>
+      ));
 
       const app = (
         <ApolloProvider client={apolloClient}>
@@ -735,11 +752,11 @@ describe('SSR', () => {
         graphql(query, {
           name: 'user',
           skip: ({ counter }) => !(counter > 1),
-        })(({ user }) =>
+        })(({ user }) => (
           <div>
             {!user || user.loading ? 'loading' : user.currentUser.firstName}
-          </div>,
-        ),
+          </div>
+        )),
       );
 
       const app = (
@@ -808,10 +825,9 @@ describe('SSR', () => {
         },
       });
 
-      const Element = ({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>;
+      const Element = ({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      );
 
       const WrappedElement = withQuery(withMutation(Element));
 
@@ -869,10 +885,9 @@ describe('SSR', () => {
       });
 
       const withMutation = graphql(mutation);
-      const Element = ({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>;
+      const Element = ({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      );
 
       const WrappedElement = withMutation(withQuery(Element));
 
@@ -907,11 +922,9 @@ describe('SSR', () => {
         addTypename: false,
       });
 
-      const WrappedElement = graphql(query)(({ data }) =>
-        <div>
-          {data.loading ? 'loading' : data.currentUser.firstName}
-        </div>,
-      );
+      const WrappedElement = graphql(query)(({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      ));
 
       class MyRootContainer extends React.Component<any, any> {
         constructor(props) {
@@ -924,11 +937,7 @@ describe('SSR', () => {
         }
 
         render() {
-          return (
-            <div>
-              {this.props.children}
-            </div>
-          );
+          return <div>{this.props.children}</div>;
         }
       }
 
@@ -1065,11 +1074,7 @@ describe('SSR', () => {
           const { data } = this.props;
           if (data.loading) return null;
           const { film } = data;
-          return (
-            <h6>
-              {film.title}
-            </h6>
-          );
+          return <h6>{film.title}</h6>;
         }
       }
 
@@ -1090,16 +1095,14 @@ describe('SSR', () => {
           const { ship } = data;
           return (
             <div>
-              <h4>
-                {ship.name} appeared in the following flims:
-              </h4>
+              <h4>{ship.name} appeared in the following flims:</h4>
               <br />
               <ul>
-                {ship.films.map((film, key) =>
+                {ship.films.map((film, key) => (
                   <li key={key}>
                     <Film id={film.id} />
-                  </li>,
-                )}
+                  </li>
+                ))}
               </ul>
             </div>
           );
@@ -1121,11 +1124,11 @@ describe('SSR', () => {
           return (
             <ul>
               {!data.loading &&
-                data.allShips.map((ship, key) =>
+                data.allShips.map((ship, key) => (
                   <li key={key}>
                     <Starship id={ship.id} />
-                  </li>,
-                )}
+                  </li>
+                ))}
             </ul>
           );
         }
@@ -1147,26 +1150,26 @@ describe('SSR', () => {
           return (
             <div>
               <h1>Planets</h1>
-              {data.allPlanets.map((planet, key) =>
-                <div key={key}>
-                  {planet.name}
-                </div>,
-              )}
+              {data.allPlanets.map((planet, key) => (
+                <div key={key}>{planet.name}</div>
+              ))}
             </div>
           );
         }
       }
 
-      const Bar = () =>
+      const Bar = () => (
         <div>
           <h2>Bar</h2>
           <AllPlanets />
-        </div>;
-      const Foo = () =>
+        </div>
+      );
+      const Foo = () => (
         <div>
           <h1>Foo</h1>
           <Bar />
-        </div>;
+        </div>
+      );
 
       const app = (
         <ApolloProvider client={apolloClient}>


### PR DESCRIPTION
Passing an updater function to `setState()` is something that React supports and people use this pattern. Fortunately, supporting that pattern in react-apollo's SSR mode is simple, so I added it and covered it with a test.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

