### PR TITLE
added clients & defaultClient option.

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -8,7 +8,9 @@ import QueryRecyclerProvider from './QueryRecyclerProvider';
 const invariant = require('invariant');
 
 export interface ProviderProps<Cache> {
-  client: ApolloClient<Cache>;
+  client?: ApolloClient<Cache>;
+  clients?: Map<string, ApolloClient<Cache>>;
+  defaultClient?: ApolloClient<Cache>;
 }
 
 export default class ApolloProvider extends Component<
@@ -16,27 +18,33 @@ export default class ApolloProvider extends Component<
   any
 > {
   static propTypes = {
-    client: PropTypes.object.isRequired,
+    client: PropTypes.object,
+    clients: PropTypes.object,
+    defaultClient: PropTypes.object,
     children: PropTypes.element.isRequired,
   };
 
   static childContextTypes = {
-    client: PropTypes.object.isRequired,
+    client: PropTypes.object,
+    clients: PropTypes.object,
+    defaultClient: PropTypes.object,
   };
 
   constructor(props, context) {
     super(props, context);
 
     invariant(
-      props.client,
-      'ApolloClient was not passed a client instance. Make ' +
-        'sure you pass in your client via the "client" prop.',
+      !!props.client || (!!props.clients && !!props.defaultClient),
+      'ApolloClient was not passed a client or clients. Make sure ' +
+        'you pass in your client(s) via the "client" or "clients" & "defaultClient" props.',
     );
   }
 
   getChildContext() {
     return {
       client: this.props.client,
+      clients: this.props.clients,
+      defaultClient: this.props.defaultClient || this.props.client,
     };
   }
 

--- a/src/QueryRecyclerProvider.tsx
+++ b/src/QueryRecyclerProvider.tsx
@@ -9,6 +9,8 @@ class QueryRecyclerProvider extends Component {
 
   static contextTypes = {
     client: PropTypes.object,
+    clients: PropTypes.object,
+    defaultClient: PropTypes.object,
   };
 
   static childContextTypes = {
@@ -24,7 +26,11 @@ class QueryRecyclerProvider extends Component {
   }
 
   componentWillReceiveProps(_, nextContext) {
-    if (this.context.client !== nextContext.client) {
+    if (
+      this.context.client !== nextContext.client ||
+      this.context.clients !== nextContext.clients ||
+      this.context.defaultClient !== nextContext.defaultClient
+    ) {
       this.recyclers = new WeakMap();
     }
   }

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -102,6 +102,8 @@ export default function graphql<
       static WrappedComponent = WrappedComponent;
       static contextTypes = {
         client: PropTypes.object,
+        clients: PropTypes.object,
+        defaultClient: PropTypes.object,
         getQueryRecycler: PropTypes.func,
       };
 
@@ -180,8 +182,10 @@ export default function graphql<
         this.shouldRerender = true;
 
         if (this.client !== client && this.client !== nextContext.client) {
-          if (client) {
+          if (client instanceof ApolloClient) {
             this.client = client;
+          } else if (typeof client === 'string') {
+            this.client = nextContext.clients[client];
           } else {
             this.client = nextContext.client;
           }
@@ -257,10 +261,12 @@ export default function graphql<
         if (this.client) return this.client;
         const { client } = mapPropsToOptions(props);
 
-        if (client) {
+        if (client instanceof ApolloClient) {
           this.client = client;
+        } else if (typeof client === 'string') {
+          this.client = this.context.clients[client];
         } else {
-          this.client = this.context.client;
+          this.client = this.context.defaultClient || this.context.client;
         }
 
         invariant(

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface MutationOpts<TVariables = OperationVariables> {
   updateQueries?: MutationQueryReducersMap;
   refetchQueries?: string[] | PureQueryOptions[];
   update?: MutationUpdaterFn;
-  client?: ApolloClient<any>;
+  client?: ApolloClient<any> | string;
   notifyOnNetworkStatusChange?: boolean;
 }
 
@@ -30,7 +30,7 @@ export interface QueryOpts<TVariables = OperationVariables> {
   variables?: TVariables;
   fetchPolicy?: FetchPolicy;
   pollInterval?: number;
-  client?: ApolloClient<any>;
+  client?: ApolloClient<any> | string;
   notifyOnNetworkStatusChange?: boolean;
   // deprecated
   skip?: boolean;

--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -23,10 +23,16 @@ export function withApollo<TProps, TResult>(
   class WithApollo extends Component<any, any> {
     static displayName = withDisplayName;
     static WrappedComponent = WrappedComponent;
-    static contextTypes = { client: PropTypes.object.isRequired };
+    static contextTypes = {
+      client: PropTypes.object,
+      clients: PropTypes.object,
+      defaultClient: PropTypes.object,
+    };
 
     // data storage
     private client: ApolloClient<any>; // apollo client
+    private clients: Map<string, ApolloClient<any>>; // apollo clients
+    private defaultClient: ApolloClient<any>;
 
     // wrapped instance
     private wrappedInstance: any;
@@ -34,6 +40,8 @@ export function withApollo<TProps, TResult>(
     constructor(props, context) {
       super(props, context);
       this.client = context.client;
+      this.clients = context.clients;
+      this.defaultClient = context.defaultClient;
       this.setWrappedInstance = this.setWrappedInstance.bind(this);
 
       invariant(
@@ -61,6 +69,8 @@ export function withApollo<TProps, TResult>(
     render() {
       const props = assign({}, this.props);
       props.client = this.client;
+      props.clients = this.clients;
+      props.defaultClient = this.defaultClient;
       if (operationOptions.withRef) props.ref = this.setWrappedInstance;
       return createElement(WrappedComponent, props);
     }

--- a/test/react-web/client/ApolloProvider.test.tsx
+++ b/test/react-web/client/ApolloProvider.test.tsx
@@ -123,10 +123,52 @@ describe('<ApolloProvider /> Component', () => {
         </ApolloProvider>,
       );
     }).toThrowError(
-      'ApolloClient was not passed a client instance. Make ' +
-        'sure you pass in your client via the "client" prop.',
+      'ApolloClient was not passed a client or clients. Make sure ' +
+        'you pass in your client(s) via the "client" or "clients" & "defaultClient" props.',
     );
     console.error = originalConsoleError;
+  });
+
+  it('should require a defaultClient when using clients', () => {
+    const originalConsoleError = console.error;
+    console.error = () => {
+      /* noop */
+    };
+    expect(() => {
+      shallow(
+        <ApolloProvider clients={{ client }}>
+          <div className="unique" />
+        </ApolloProvider>,
+      );
+    }).toThrowError(
+      'ApolloClient was not passed a client or clients. Make sure ' +
+        'you pass in your client(s) via the "client" or "clients" & "defaultClient" props.',
+    );
+    console.error = originalConsoleError;
+  });
+
+  it('should support multiple clients & defaultClient', () => {
+    const newClient = new ApolloClient({
+      cache: new Cache(),
+      link: new ApolloLink((o, f) => f(o)),
+    });
+
+    const wrapper = shallow(
+      <div>
+        <ApolloProvider
+          clients={{ main: client, newClient: newClient }}
+          defaultClient={client}
+        >
+          <div className="unique" />
+        </ApolloProvider>
+      </div>,
+    );
+
+    expect(wrapper.find(ApolloProvider).props().clients.main).toBe(client);
+    expect(wrapper.find(ApolloProvider).props().clients.newClient).toBe(
+      newClient,
+    );
+    expect(wrapper.find(ApolloProvider).props().defaultClient).toBe(client);
   });
 
   it('should not require a store', () => {


### PR DESCRIPTION
So, I the client option was merged where users can pass in a Client to override the client in ApolloProvider.  One pain that I've come across using this method is that for SSR, it's complicates things when you need to create a new client per HTTP request.  Without multiple clients, in typical react-apollo setups, this works fine because each request wraps the app in ApolloClient, runs getDataFromTree, etc, etc.  When using SSR, this example in the comments when the client option was originally merged makes it difficult (because the cache is somewhat lost, unless you pass around the original created one)

Current Implementation:

```js
// This is fine on the browser since you can locally cache "other-client" 
// and re-use... but a pain for SSR.
import MyOtherClient from "../other-client"

export default graphql(MyQuery, {
  client: MyOtherClient,
})(MyComponent);
```

This PR adds this functionality:

```js
// Store.js
export default graphql(gql(`...`))(Products); // uses default client

// Repositories.js
export default graphql(gql(`...`), {
  options: {
    client: 'github'
  }
})(Repos);

// App.js
<ApolloProvider clients={{ shopify, github }} defaultClient={shopify}>
  <App>
    <Store />
    <Repositories />
  </App>
</ApolloProvider>
```

I know I'm supposed to create PRs only if there's a consensus, but it was more of a pain setting up an environment to show my use-case than it was to just see if moving all clients to the provider context would fix it.  After I added all of this, it indeed fixed my issue where double fetching on the server & browser would happen.

This still needs a few more tests and error handling when clients with invalid names don't exist, etc.

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)

https://github.com/apollographql/react-apollo/issues/1232

- [X] Make sure all of the significant new logic is covered by tests

I still need to add a few more tests and clean things up.

- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
