### PR TITLE
Fix typescript interface

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -7,14 +7,11 @@ import QueryRecyclerProvider from './QueryRecyclerProvider';
 
 const invariant = require('invariant');
 
-export interface ProviderProps<Cache> {
-  client: ApolloClient<Cache>;
+export interface ProviderProps {
+  client: ApolloClient<any>;
 }
 
-export default class ApolloProvider extends Component<
-  ProviderProps<Cache>,
-  any
-> {
+export default class ApolloProvider extends Component<ProviderProps, any> {
   static propTypes = {
     client: PropTypes.object.isRequired,
     children: PropTypes.element.isRequired,


### PR DESCRIPTION
Fixes `Type 'ApolloClient<NormalizedCache>' is not assignable to type 'ApolloClient<Cache>'.` errors.

My typescript foo is weak so I'm not sure if I'm doing what @corydeppen suggested in https://github.com/apollographql/react-apollo/issues/1299#issuecomment-340275539? My changes worked for me at least.

Closes https://github.com/apollographql/react-apollo/issues/1299