### PR TITLE
Fix <ApolloProvider/> typings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Support arrays being returned from render in SSR [#1158](https://github.com/apollographql/react-apollo/pull/1158)
 - Support passing an updater function to `setState` in SSR mode [#1263](https://github.com/apollographql/react-apollo/pull/1263)
 - Correctly initializes component state as null (not undefined) [#1300](https://github.com/apollographql/react-apollo/pull/1310)
+- Correctly provide the generic cache type to ApolloProvider [#1319](https://github.com/apollographql/react-apollo/pull/1319)
 
 ### 2.0.0-beta.0
 - upgrade to Apollo Client 2.0

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -7,12 +7,12 @@ import QueryRecyclerProvider from './QueryRecyclerProvider';
 
 const invariant = require('invariant');
 
-export interface ProviderProps<Cache> {
-  client: ApolloClient<Cache>;
+export interface ProviderProps<TCache> {
+  client: ApolloClient<TCache>;
 }
 
-export default class ApolloProvider extends Component<
-  ProviderProps<Cache>,
+export default class ApolloProvider<TCache> extends Component<
+  ProviderProps<TCache>,
   any
 > {
   static propTypes = {


### PR DESCRIPTION
This fixes the typings of ApolloProvider.

>Rather than using the Cache type, which is defined in the TypeScript lib.dom.d.ts declaration file, for the generic parameter to ProviderProps in the ApolloProvider class, it may be more appropriate to use any to let the type flow through when the client is created. It may also be less confusing if the generic type parameter was renamed to something like TCache in the ProviderProps interface definition so it's not confused with the Cache type.
>
> I tested this change in the ApolloProvider.d.ts file and noticed the error went away and the client was properly typed as NormalizedCache when defining the cache as InMemoryCache.

Ref: https://github.com/apollographql/react-apollo/issues/1299
