### PR TITLE
Added graphql-tag to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ Now you may create components in this React tree that are connected to your Grap
 
 Finally, to demonstrate the power of React Apollo in building interactive UIs let us connect one of your component’s to your GraphQL server using the [`graphql()`][] component enhancer:
 
+You'll need install `graphql-tag` to use `gql` module:
+
+```bash
+npm install graphql-tag --save
+```
+
 ```js
-import { gql, graphql } from 'react-apollo';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
 
 function TodoApp({ data: { todos, refetch } }) {
   return (


### PR DESCRIPTION
I added `graphql-tag` in README.md.

It's not working: `import { gql } from 'react-apollo';`