### PR TITLE
Include link to react-apollo 2.x docs in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ For an amazing developer experience you may also install the [Apollo Client Deve
 
 ## Usage
 
+*Note: The following pertains to react-apollo 1.x. Docs on setting up 2.x can be found [here](https://www.apollographql.com/docs/react/basics/setup.html)*
+
 To get started you will first want to create an instance of [`ApolloClient`][] and then you will want to provide that client to your React component tree using the [`<ApolloProvider/>`][] component. Finally, we will show you a basic example of connecting your GraphQL data to your React components with the [`graphql()`][] enhancer function.
 
 First we want an instance of [`ApolloClient`][]. We can import the class from `react-apollo` and construct it like so:


### PR DESCRIPTION
I see we have [this PR](https://github.com/apollographql/react-apollo/pull/1337) up to update the README, which is great, but I noticed that a) it doesn't address setup for users of react-apollo 1.x  and b) it recreates documentation that exists on apollographql.com (specifically, [these](https://www.apollographql.com/docs/react/basics/setup.html)). 

This "solution" preserves the 1.x docs while also directing users of 2.x to the appropriate place.

