### PR TITLE
docs(readme): Add link to React Apollo 1.x docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ React Apollo is:
 
 Get started today on the app you’ve been dreaming of, and let React Apollo take you to the moon!
 
+> **Looking for React Apollo 1.x documentation**? The 1.x documention is available [here](https://s3.amazonaws.com/apollo-docs-1.x/index.html).
+
 ## Installation
 
 It is simple to install React Apollo and related libraries.


### PR DESCRIPTION
Fixes #1326, implements https://github.com/apollographql/react-apollo/pull/1340#issuecomment-344712506

There are tons of users still on `1.x` and there's lots of people asking for the docs on Slack (and GitHub).  For many GitHub README is the first place to look for documentation but the documents currently only cover 2.x. This PR adds a link to the old documentary hosted on `aws` (sorry, can't remember by who).