### PR TITLE
Skip null array items in `getDataFromTree`

### DIFF
--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -36,6 +36,9 @@ export function walkTree<Cache>(
 
     return;
   }
+
+  if (element === null) return;
+
   const Component = element.type;
   // a stateless functional component or a class
   if (typeof Component === 'function') {

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -147,6 +147,16 @@ describe('SSR', () => {
         expect(elementCount).toEqual(3);
       });
 
+      it('function stateless components that render with a null in array', () => {
+        let elementCount = 0;
+
+        const MyComponent = () => [null, <div />];
+        walkTree(<MyComponent />, {}, element => {
+          elementCount += 1;
+        });
+        expect(elementCount).toEqual(2);
+      });
+
       it('basic classes', () => {
         let elementCount = 0;
         class MyComponent extends React.Component<any, any> {
@@ -184,6 +194,20 @@ describe('SSR', () => {
           elementCount += 1;
         });
         expect(elementCount).toEqual(3);
+      });
+
+      it('basic classes components that render with a null in array', () => {
+        let elementCount = 0;
+
+        class MyComponent extends React.Component<any, any> {
+          render() {
+            return [null, <div />];
+          }
+        }
+        walkTree(<MyComponent />, {}, element => {
+          elementCount += 1;
+        });
+        expect(elementCount).toEqual(2);
       });
 
       it('basic classes with incomplete constructors', () => {


### PR DESCRIPTION
I have the case that occasionally a component may return an array with a `null` value in it. Unfortunately this breaks the tree walker and eventually our server side rendering:
> Cannot read property 'type' of undefined
>     at walkTree (/.../node_modules/react-apollo/react-apollo.umd.js:674:34)

From the React standpoint this should be totally fine: https://codesandbox.io/s/y0pl8pkwnx.

So in this PR I added a null check and tests to cover this case.