### PR TITLE
docs(readme): Remove the mention about `react-redux` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const client = new ApolloClient({
 
 > Migrating from 1.x? See the [2.0 migration guide](https://www.apollographql.com/docs/react/2.0-migration.html).
 
-Next you will want to add a [`<ApolloProvider/>`][] component to the root of your React component tree. This component works almost the same as the [`<Provider/>` component in `react-redux`][]. In fact if you pass a `store` prop into [`<ApolloProvider/>`][] it will also serve as a provider for `react-redux`! To use an [`<ApolloProvider/>`][] with your newly constructed client see the following:
+Next you will want to add a [`<ApolloProvider/>`][] component to the root of your React component tree. This component [provides](https://reactjs.org/docs/context.html) the React Apollo functionality to all the other components in the application without passing it explicitly. To use an [`<ApolloProvider/>`][] with your newly constructed client see the following:
 
 ```js
 import { ApolloProvider } from 'react-apollo';


### PR DESCRIPTION
This PR removes the mention about `react-redux` functionality, as in 2.0 the `<ApolloProvider />` is not based on `react-redux`s `<Provider>` anymore.
