### PR TITLE
feat(graphql): Added Variable generic type

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -67,11 +67,12 @@ let nextVersion = 0;
 export default function graphql<
   TResult = {},
   TProps = {},
-  TChildProps = ChildProps<TProps, TResult>
+  TChildProps = ChildProps<TProps, TResult>,
+  TGraphQLVariables = {}
 >(
   document: DocumentNode,
-  operationOptions: OperationOption<TProps, TResult> = {},
-): ComponentDecorator<TProps, TChildProps> {
+  operationOptions: OperationOption<TProps & TGraphQLVariables, TResult> = {},
+): ComponentDecorator<TProps & TGraphQLVariables, TChildProps> {
   // extract options
   const {
     options = defaultMapPropsToOptions,
@@ -97,7 +98,7 @@ export default function graphql<
   function wrapWithApolloComponent(WrappedComponent) {
     const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
 
-    class GraphQL extends Component<TProps, void> {
+    class GraphQL extends Component<TProps & TGraphQLVariables, void> {
       static displayName = graphQLDisplayName;
       static WrappedComponent = WrappedComponent;
       static contextTypes = {
@@ -320,7 +321,7 @@ export default function graphql<
         let name = this.type === DocumentType.Mutation ? 'mutate' : 'data';
         if (operationOptions.name) name = operationOptions.name;
 
-        const newResult: OptionProps<TProps, TResult> = {
+        const newResult: OptionProps<TProps & TGraphQLVariables, TResult> = {
           [name]: result,
           ownProps: this.props,
         };

--- a/test/react-web/client/graphql/queries/index.test.tsx
+++ b/test/react-web/client/graphql/queries/index.test.tsx
@@ -14,7 +14,7 @@ import { withState } from 'recompose';
 declare function require(name: string);
 
 import { mockSingleLink } from '../../../../../src/test-utils';
-import { ApolloProvider, graphql } from '../../../../../src';
+import { ApolloProvider, graphql, ChildProps } from '../../../../../src';
 import { DocumentType } from '../../../../../src/parser';
 
 // XXX: this is also defined in apollo-client
@@ -107,7 +107,26 @@ describe('queries', () => {
       cache: new Cache({ addTypename: false }),
     });
 
-    const ContainerWithData = graphql(query)(({ data }) => {
+    // Ensure variable types work correctly here
+
+    type TResult = {
+      allPeople: {
+        people: {
+          name: string;
+        };
+      };
+    };
+
+    type TVariables = {
+      first: number;
+    };
+
+    const ContainerWithData = graphql<
+      TResult,
+      {},
+      ChildProps<{}, TResult>,
+      TVariables
+    >(query)(({ data }) => {
       // tslint:disable-line
       expect(data).toBeTruthy();
       expect(data.variables).toEqual(variables);


### PR DESCRIPTION
Originally opened as PR #1259, rebased by hand when Apollo-client 2.0 dropped.

Added a type generic to the graphql function named TGraphQLVariables.
It allows for specifying types that are required for the query that
should NOT be passed to the underlying component but are just used
for the GraphQL operation. The type is joined to the component's TProps
but not required on the passed in component.

Per apollographql/apollo-client#2198

This should not effect any current implementations as it defaults to {}.

Checklist:

- [x]  If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x]  Make sure all of the significant new logic is covered by tests
- [x]  If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
