### PR TITLE
Include flow check in the CI process.

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "enzyme-adapter-react-16": "^1.0.0",
     "enzyme-to-json": "1.6.0",
     "flow-bin": "0.59.0",
-    "graphql": "^0.11.7",
+    "graphql": "0.11.7",
     "graphql-tag": "^2.0.0",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "enzyme-adapter-react-16": "^1.0.0",
     "enzyme-to-json": "1.6.0",
     "flow-bin": "0.59.0",
-    "graphql": "0.11.4",
+    "graphql": "^0.11.7",
     "graphql-tag": "^2.0.0",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
   "scripts": {
     "deploy": "./scripts/deploy.sh",
     "danger": "danger run --verbose",
-    "test": "npm run compile && jest",
+    "test":
+      "npm run compile && npm run type-check:flow && npm run type-check:ts && jest",
     "testonly": "jest",
     "test-watch": "jest --watch",
     "posttest": "npm run lint && npm run type-check",
     "filesize": "npm run compile:browser && bundlesize",
-    "type-check":
+    "type-check:ts":
       "tsc ./test/typescript.ts --noEmit --jsx react --noEmitOnError --lib es6,dom --experimentalDecorators",
+    "type-check:flow": "flow check test/flow.js --include-warnings",
     "compile": "tsc",
     "bundle":
       "rollup -c && rollup -c rollup.browser.config.js && rollup -c rollup.test-utils.config.js",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "scripts": {
     "deploy": "./scripts/deploy.sh",
     "danger": "danger run --verbose",
-    "test":
-      "npm run compile && npm run type-check:flow && npm run type-check:ts && jest",
+    "test": "npm run compile && jest",
     "testonly": "jest",
     "test-watch": "jest --watch",
     "posttest": "npm run lint && npm run type-check",
     "filesize": "npm run compile:browser && bundlesize",
+    "type-check": "npm run type-check:flow && npm run type-check:ts",
     "type-check:ts":
       "tsc ./test/typescript.ts --noEmit --jsx react --noEmitOnError --lib es6,dom --experimentalDecorators",
     "type-check:flow": "flow check test/flow.js --include-warnings",

--- a/test/flow.js
+++ b/test/flow.js
@@ -10,6 +10,7 @@
 */
 
 // @flow
+import React from 'react';
 import gql from 'graphql-tag';
 import { withApollo, compose, graphql } from '../src';
 import type { OperationComponent, QueryProps, ChildProps } from '../src';


### PR DESCRIPTION
In ran into issues trying to integrate flow into an example project in #1372. I decided to investigate further and found out that the flow tests included in this repo contain all kinds of flow errors.

To highlight these errors I added the flow and typescript type check to the CI script. I think that it is valuable to include these checks in CI to prevent issues from occurring.

I fixed the errors by adding a React import statement to the `test/flow.js` file and updating the GraphQL dev dependency.