### PR TITLE
Fix issue with SSR that has undefined array elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,11 +2,10 @@
 
 ### vNext
 
-### 2.0.1
 - upgraded required apollo-client for bugfix for subscriptions
 - add component name in unhandled error message [#1362](https://github.com/apollographql/react-apollo/pull/1362)
 - upgraded flow support to 0.59.0 :tada: [#1354](https://github.com/apollographql/react-apollo/pull/1354)
-- skip null items on SSR if present [#1355](https://github.com/apollographql/react-apollo/pull/1355)
+- skip null / undefined items on SSR if present [#1355](https://github.com/apollographql/react-apollo/pull/1355)
 
 
 ### 2.0.1

--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -37,7 +37,7 @@ export function walkTree<Cache>(
     return;
   }
 
-  if (element === null) return;
+  if (element == null) return;
 
   const Component = element.type;
   // a stateless functional component or a class

--- a/test/react-web/server/index.test.tsx
+++ b/test/react-web/server/index.test.tsx
@@ -157,6 +157,16 @@ describe('SSR', () => {
         expect(elementCount).toEqual(2);
       });
 
+      it('function stateless components that render with a undefined in array', () => {
+        let elementCount = 0;
+
+        const MyComponent = () => [undefined, <div />];
+        walkTree(<MyComponent />, {}, element => {
+          elementCount += 1;
+        });
+        expect(elementCount).toEqual(2);
+      });
+
       it('basic classes', () => {
         let elementCount = 0;
         class MyComponent extends React.Component<any, any> {


### PR DESCRIPTION
Recently #1355 was merged in to handle `null` elements. It's also possible, however, to return `undefined` elements and React is able to handle these just fine. `react-apollo` should support them as well.