### PR TITLE
Revert "Use lodash-es for ES modules (#1344)"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Change log
 
 ### vNext
+
+### 2.0.4
+- Revert lodash-es module change for transpilation failures [#1392](https://github.com/apollographql/react-apollo/pull/1392)
+
+### 2.0.3
 - Use lodash-es to allow lodash functions to be used in ES modules [#1344](https://github.com/apollographql/react-apollo/pull/1344)
 - turn back on flow checking
 

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "transform": {
       ".*": "./preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(lodash-es|react-native)/)"
-    ],
     "moduleFileExtensions": ["ts", "tsx", "js", "json"],
     "modulePathIgnorePatterns": [
       "<rootDir>/examples",
@@ -95,8 +92,7 @@
     "@types/invariant": "2.2.29",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "20.0.8",
-    "@types/lodash": "4.14.86",
-    "@types/lodash-es": "4.17.0",
+    "@types/lodash": "4.14.74",
     "@types/node": "8.0.31",
     "@types/object-assign": "4.0.30",
     "@types/react": "16.0.28",
@@ -109,9 +105,7 @@
     "@types/zen-observable": "0.5.3",
     "apollo-cache-inmemory": "1.1.3",
     "apollo-client": "2.1.0",
-    "babel-core": "^6.26.0",
     "babel-jest": "20.0.3",
-    "babel-preset-env": "^1.6.1",
     "babel-preset-react-native": "3.0.2",
     "bundlesize": "0.14.4",
     "cheerio": "0.22.0",
@@ -166,7 +160,8 @@
     "apollo-link": "^1.0.0",
     "hoist-non-react-statics": "^2.2.0",
     "invariant": "^2.2.1",
-    "lodash-es": "^4.17.4",
+    "lodash.flowright": "^3.5.0",
+    "lodash.pick": "^4.4.0",
     "prop-types": "^15.5.8"
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,5 +16,5 @@ export { withApollo } from './withApollo';
 export { getDataFromTree } from './getDataFromTree';
 
 // expose easy way to join queries from redux
-import flowRight from 'lodash-es/flowRight';
-export { flowRight as compose };
+import * as compose from 'lodash.flowright';
+export { compose };

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -5,7 +5,7 @@ import shallowEqual from './shallowEqual';
 
 const invariant = require('invariant');
 const assign = require('object-assign');
-import pick from 'lodash-es/pick';
+const pick = require('lodash.pick');
 
 const hoistNonReactStatics = require('hoist-non-react-statics');
 


### PR DESCRIPTION
This reverts commit 8085a9485d3938d90ac1c9b97cef2621ce568ced.

Fixes #1390

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
