### PR TITLE
Fully type `ChildProps` and reorder `graphql()` types to reduce verbosity

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Change log
 
 ### next
-- Added optional `V` parameterized type on `ChildProps` to pass through to `MutationFunc<V>` [#1395](https://github.com/apollographql/react-apollo/pull/1395)
-- Reordered parameterized types on `graphql` to shorten required types allowing `ChildProps` to be fully derived with optional variables type passed through [#1395](https://github.com/apollographql/react-apollo/pull/1395)
+- Added optional `TVariables` parameterized type on `ChildProps` to pass through to `MutationFunc<TResult, TVariables>` [#1395](https://github.com/apollographql/react-apollo/pull/1395)
+- Reordered parameterized types on `graphql` to match `ChildProps` and shorten required types allowing `ChildProps` to be fully derived with optional variables type passed through [#1395](https://github.com/apollographql/react-apollo/pull/1395)
 
 
 ### 2.0.4

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+### next
+- Added optional `V` parameterized type on `ChildProps` to pass through to `MutationFunc<V>` [#1395](https://github.com/apollographql/react-apollo/pull/1395)
+- Reordered parameterized types on `graphql` to shorten required types allowing `ChildProps` to be fully derived with optional variables type passed through [#1395](https://github.com/apollographql/react-apollo/pull/1395)
+
+
 ### 2.0.4
 - rolled back on the lodash-es changes from
   [#1344](https://github.com/apollographql/react-apollo/pull/1344) due to build

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -67,8 +67,8 @@ let nextVersion = 0;
 export default function graphql<
   TResult = {},
   TProps = {},
-  TChildProps = ChildProps<TProps, TResult>,
-  TGraphQLVariables = {}
+  TGraphQLVariables = {},
+  TChildProps = ChildProps<TProps, TResult, TGraphQLVariables>
 >(
   document: DocumentNode,
   operationOptions: OperationOption<TProps & TGraphQLVariables, TResult> = {},
@@ -306,9 +306,8 @@ export default function graphql<
             `The operation '${operation.name}' wrapping '${getDisplayName(
               WrappedComponent,
             )}' ` +
-              `is expecting a variable: '${
-                variable.name.value
-              }' but it was not found in the props ` +
+              `is expecting a variable: '${variable.name
+                .value}' but it was not found in the props ` +
               `passed to '${graphQLDisplayName}'`,
           );
         }
@@ -446,9 +445,7 @@ export default function graphql<
           const clashingKeys = Object.keys(observableQueryFields(results.data));
           invariant(
             clashingKeys.length === 0,
-            `the result of the '${
-              graphQLDisplayName
-            }' operation contains keys that ` +
+            `the result of the '${graphQLDisplayName}' operation contains keys that ` +
               `conflict with the return object.` +
               clashingKeys.map(k => `'${k}'`).join(', ') +
               ` not allowed.`,

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -65,8 +65,8 @@ function getDisplayName(WrappedComponent) {
 let nextVersion = 0;
 
 export default function graphql<
-  TResult = {},
   TProps = {},
+  TResult = {},
   TGraphQLVariables = {},
   TChildProps = ChildProps<TProps, TResult, TGraphQLVariables>
 >(

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,9 +63,9 @@ export interface OptionProps<TProps, TResult> {
   mutate?: MutationFunc<TResult>;
 }
 
-export type ChildProps<P, R> = P & {
+export type ChildProps<P, R, V = OperationVariables> = P & {
   data?: QueryProps & Partial<R>;
-  mutate?: MutationFunc<R>;
+  mutate?: MutationFunc<R, V>;
 };
 
 export type NamedProps<P, R> = P & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,9 +63,13 @@ export interface OptionProps<TProps, TResult> {
   mutate?: MutationFunc<TResult>;
 }
 
-export type ChildProps<P, R, V = OperationVariables> = P & {
-  data?: QueryProps & Partial<R>;
-  mutate?: MutationFunc<R, V>;
+export type ChildProps<
+  TProps,
+  TResult,
+  TVariables = OperationVariables
+> = TProps & {
+  data?: QueryProps & Partial<TResult>;
+  mutate?: MutationFunc<TResult, TVariables>;
 };
 
 export type NamedProps<P, R> = P & {


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

---

## Context
I have a fully typescript codebase, and am using `apollo-codegen` to generate types for mutations and queries.  I found using a fully typed `react-apollo` was not possible with the current type `ChildProps` helper, and very verbose with the `graphql` parameterized type ordering.

This changes/fixes parameterized types only and does not affect any runtime code.

## Problems
- `ChildProps` - is not fully parameterized and does not allow passing through of variables to `MutationFunc`
- `graphql` parameterized type ordering places a derived type `ChildProps` in the third position, making a really verbose fully typed usage
- `graphql` parameterized type did not pass `TVariables` to derived type `ChildProps`
- `graphql` parameterized type ordering now matches `ChildProps` for consistency - `props, operation, operation variables`

## Before example usage

```js
class MyDialog extends React.Component<
  ChildProps<MyDialogProps, UpdateMutation>, // <= Mutation variables untyped
  State
  > {
}
export default graphql<
  UpdateMutation, 
  MyDialogProps, 
  ChildProps<MyDialogProps, UpdateMutation>, // <= Mutation variables untyped and derived type ordering causes more verbose specification of parameterized types 
  UpdateMutationVariables>(
  UPDATE,
)(MyDialog)
```

## After example usage

```js
class MyDialog extends React.Component<
  ChildProps<MyDialogProps, UpdateMutation, UpdateMutationVariables>,
  State
  > {
}

export default graphql<MyDialogProps, UpdateMutation, UpdateMutationVariables>(
  UPDATE,
)(MyDialog)
```

