### PR TITLE
fix: refactor imports/exports to play nicely with webpack

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change log
 
+### next
+- refactor imports/exports to play nicely with webpack
+
 ### 2.0.4
 - rolled back on the lodash-es changes from
   [#1344](https://github.com/apollographql/react-apollo/pull/1344) due to build

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
 export * from './browser';
-export { getDataFromTree, walkTree } from './getDataFromTree';
+import {
+  getDataFromTree as _getDataFromTree,
+  walkTree as _walkTree,
+} from './getDataFromTree';
+
+export const getDataFromTree = _getDataFromTree;
+export const walkTree = _walkTree;
+
 export { renderToStringWithData } from './server';
+//# sourceMappingURL=index.js.map

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './browser';
-export { getDataFromTree, renderToStringWithData, walkTree } from './server';
+export { getDataFromTree, walkTree } from './getDataFromTree';
+export { renderToStringWithData } from './server';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,3 @@ export const getDataFromTree = _getDataFromTree;
 export const walkTree = _walkTree;
 
 export { renderToStringWithData } from './server';
-//# sourceMappingURL=index.js.map

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import { ReactElement } from 'react';
 import * as ReactDOM from 'react-dom/server';
 
 import { getDataFromTree } from './getDataFromTree';
-export * from './getDataFromTree';
 
 export function renderToStringWithData(
   component: ReactElement<any>,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,12 @@
+import { ReactElement } from 'react';
 import * as ReactDOM from 'react-dom/server';
+
 import { getDataFromTree } from './getDataFromTree';
 
-export function renderToStringWithData(component) {
-  return getDataFromTree(component).then(function() {
-    return ReactDOM.renderToString(component);
-  });
+export function renderToStringWithData(
+  component: ReactElement<any>,
+): Promise<string> {
+  return getDataFromTree(component).then(() =>
+    ReactDOM.renderToString(component),
+  );
 }
-//# sourceMappingURL=server.js.map

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,9 @@
-import { ReactElement } from 'react';
 import * as ReactDOM from 'react-dom/server';
-
 import { getDataFromTree } from './getDataFromTree';
 
-export function renderToStringWithData(
-  component: ReactElement<any>,
-): Promise<string> {
-  return getDataFromTree(component).then(() =>
-    ReactDOM.renderToString(component),
-  );
+export function renderToStringWithData(component) {
+  return getDataFromTree(component).then(function() {
+    return ReactDOM.renderToString(component);
+  });
 }
+//# sourceMappingURL=server.js.map


### PR DESCRIPTION
Fixes #1409 
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Issue: We were getting an error in the browser:

```
Uncaught TypeError: Cannot redefine property: getDataFromTree
   at Function.defineProperty (<anonymous>)
   at Object.<anonymous> (lib-7fd04c4927421371.js:1)
   at t (lib-7fd04c4927421371.js:1)
   at Object.92 (app-7fd04c4927421371.js:1)
   at t (lib-7fd04c4927421371.js:1)
   at Object.91 (app-7fd04c4927421371.js:1)
   at t (lib-7fd04c4927421371.js:1)
   at Object.<anonymous> (app-7fd04c4927421371.js:1)
   at Object.622 (app-7fd04c4927421371.js:1)
   at t (lib-7fd04c4927421371.js:1)```
```

We found that this issue is related to some module imports/exports in the [server.ts](https://github.com/apollographql/react-apollo/blob/master/src/server.ts)

```
...
import { getDataFromTree } from './getDataFromTree';
export * from './getDataFromTree';
...
```

It appears that there is a collision with getDataFromTree when exporting. We've only seen this issue occur when using webpack to bundle up components for an app.

The fix we put in is to remove the `export * from './getDataFromTree';` from server.ts and import getDataFromTree and walkTree into index.ts.

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests
No new logic, just a change in imports

