### PR TITLE
Make errors.test more lenient for travis

### DIFF
--- a/test/react-web/client/graphql/queries/errors.test.tsx
+++ b/test/react-web/client/graphql/queries/errors.test.tsx
@@ -349,7 +349,7 @@ describe('[queries] errors', () => {
         } finally {
           console.error = origError;
         }
-      }, 50);
+      }, 250);
     }));
 
   it('passes any cached data when there is a GraphQL error', done => {


### PR DESCRIPTION
`errors.test` is a frequent flaky offender on travis.  Increase the timeout to 250ms (hopefully that is enough) to ensure computation time to render component and gather count.