### PR TITLE
Made prettier responsible for all formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "travis-weigh-in": "1.0.2",
     "ts-jest": "22.0.0",
     "tslint": "5.8.0",
+    "tslint-config-prettier": "^1.6.0",
     "typescript": "2.6.2",
     "typescript-require": "0.2.9",
     "typings": "2.1.1",

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["tslint-config-prettier"],
   "rules": {
     "align": [false, "parameters", "arguments", "statements"],
     "ban": false,
@@ -39,7 +40,6 @@
     "no-unused-expression": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
-    "no-var-requires": false,
     "object-literal-sort-keys": false,
     "one-line": [
       true,


### PR DESCRIPTION
This PR makes prettier responsible for all formatting. This is something that is needed in PR #1448 where the conflicting formatting rules between prettier and tslint is causing issues.