### PR TITLE
Updated lint rule to make prettier responsible for formatting.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ first three params (`TChildProps` can be derived). [#1402](https://github.com/ap
 - Typescript - fix `graphql` HOC inference [#1402](https://github.com/apollographql/react-apollo/pull/1402)
 - **Remove deprecated** `operationOptions.options.skip`, use `operationOptions.skip` instead
 - Added <Query /> component [#1399](https://github.com/apollographql/react-apollo/pull/1398)
+- Made prettier solely responsible for formatting, removed all formatting linting rules from tslint [#1452](https://github.com/apollographql/react-apollo/pull/1452)
 
 ### 2.0.4
 - rolled back on the lodash-es changes from

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint-staged": "lint-staged",
     "lint-fix":
       "npm run pretty && tslint 'src/*.ts*' --project tsconfig.json --fix",
-    "pretty": "prettier --config .prettierrc --write \"{src,test}/**/*.ts*\""
+    "pretty":
+      "prettier --config .prettierrc --write \"{src,test}/**/*.{js,ts}*\""
   },
   "bundlesize": [
     {
@@ -42,8 +43,7 @@
     }
   ],
   "lint-staged": {
-    "*.ts*": ["prettier --config .prettierrc --write", "git add"],
-    "*.js*": ["prettier --config .prettierrc --write", "git add"]
+    "*.{js,ts}*": ["prettier --single-quote --write", "git add"]
   },
   "pre-commit": "lint-staged",
   "repository": {
@@ -141,7 +141,6 @@
     "travis-weigh-in": "1.0.2",
     "ts-jest": "22.0.0",
     "tslint": "5.8.0",
-    "tslint-config-prettier": "^1.6.0",
     "typescript": "2.6.2",
     "typescript-require": "0.2.9",
     "typings": "2.1.1",

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -123,7 +123,7 @@ class Query extends React.Component<QueryProps, QueryState> {
     return children(result);
   }
 
-  private initializeQueryObservable(props) {
+  private initializeQueryObservable = props => {
     const {
       variables,
       pollInterval,
@@ -136,10 +136,9 @@ class Query extends React.Component<QueryProps, QueryState> {
 
     invariant(
       operation.type === DocumentType.Query,
-      `The <Query /> component requires a graphql query, but got a ${operation.type ===
-      DocumentType.Mutation
-        ? 'mutation'
-        : 'subscription'}.`,
+      `The <Query /> component requires a graphql query, but got a ${
+        operation.type === DocumentType.Mutation ? 'mutation' : 'subscription'
+      }.`,
     );
 
     const clientOptions = {
@@ -151,26 +150,26 @@ class Query extends React.Component<QueryProps, QueryState> {
     };
 
     this.queryObservable = this.client.watchQuery(clientOptions);
-  }
+  };
 
-  private startQuerySubscription() {
+  private startQuerySubscription = () => {
     this.querySubscription = this.queryObservable.subscribe({
       next: this.updateCurrentData,
       error: this.updateCurrentData,
     });
-  }
+  };
 
-  private removeQuerySubscription() {
+  private removeQuerySubscription = () => {
     if (this.querySubscription) {
       this.querySubscription.unsubscribe();
     }
-  }
+  };
 
-  private updateCurrentData() {
+  private updateCurrentData = () => {
     this.setState({ result: this.queryObservable.currentResult() });
-  }
+  };
 
-  private getResult() {
+  private getResult = () => {
     const { result } = this.state;
 
     const { loading, error, networkStatus, data } = result;
@@ -184,7 +183,7 @@ class Query extends React.Component<QueryProps, QueryState> {
     };
 
     return renderProps;
-  }
+  };
 }
 
 export default Query;

--- a/tslint.json
+++ b/tslint.json
@@ -1,16 +1,12 @@
 {
-  "extends": ["tslint-config-prettier"],
   "rules": {
     "align": [false, "parameters", "arguments", "statements"],
     "ban": false,
     "class-name": true,
     "curly": false,
-    "eofline": true,
     "forin": false,
-    "indent": [true, "spaces"],
     "jsdoc-format": true,
     "label-position": true,
-    "max-line-length": [true, 140],
     "member-access": false,
     "member-ordering": [
       true,
@@ -36,22 +32,11 @@
     "no-var-requires": false,
     "no-shadowed-variable": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-finally",
-      "check-whitespace"
-    ],
-    "quotemark": [true, "single", "avoid-escape", "jsx-double"],
     "radix": true,
-    "semicolon": [true, "always"],
     "switch-default": true,
     "triple-equals": [true, "allow-null-check"],
     "typedef": [
@@ -63,36 +48,11 @@
       "variable-declaration",
       "member-variable-declaration"
     ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      },
-      {
-        "call-signature": "space",
-        "index-signature": "space",
-        "parameter": "space",
-        "property-declaration": "space",
-        "variable-declaration": "space"
-      }
-    ],
     "variable-name": [
       false,
       "check-format",
       "allow-leading-underscore",
       "ban-keywords"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
     ]
   }
 }


### PR DESCRIPTION
Following #1449, attempt 2 at making prettier responsible for formatting.

I used a tool to remove all the lint rules that conflicted with prettier in the tslint.json. I also tested it on the file `Query.tsx` that is causing issues in #1448. 

This allowed me to remove `tslint-config-prettier` as a dependency.

Finally, I also updated the `pretty` script and the lint-staged script in the `package.json`.