### PR TITLE
Fixed the typings for the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/graphql": "0.11.7",
     "@types/invariant": "2.2.29",
     "@types/isomorphic-fetch": "0.0.34",
-    "@types/jasmine": "2.8.2",
     "@types/jest": "21.1.9",
     "@types/lodash": "4.14.91",
     "@types/object-assign": "4.0.30",

--- a/test/react-web/client/graphql/queries/api.test.tsx
+++ b/test/react-web/client/graphql/queries/api.test.tsx
@@ -11,6 +11,7 @@ import {
   OptionProps,
 } from '../../../../../src';
 import '../../../../test-utils/toEqualJson';
+import stripSymbols from '../../../../test-utils/stripSymbols';
 import wrap from '../../../../test-utils/wrap';
 
 describe('[queries] api', () => {
@@ -68,12 +69,12 @@ describe('[queries] api', () => {
           data
             .refetch()
             .then(result => {
-              expect(result.data).toEqualJson(data1);
+              expect(stripSymbols(result.data)).toEqual(data1);
               return data
                 .refetch({ first: 2 }) // new variables
                 .then(response => {
-                  expect(response.data).toEqualJson(data1);
-                  expect(data.allPeople).toEqualJson(data1.allPeople);
+                  expect(stripSymbols(response.data)).toEqual(data1);
+                  expect(stripSymbols(data.allPeople)).toEqual(data1.allPeople);
                   done();
                 });
             })

--- a/test/test-utils/stripSymbols.ts
+++ b/test/test-utils/stripSymbols.ts
@@ -1,0 +1,9 @@
+/**
+ * Apollo-client adds Symbols to the data in the store. In order to make
+ * assertions in our tests easier we strip these Symbols from the data.
+ */
+const stripSymbols = data => {
+  return JSON.parse(JSON.stringify(data));
+};
+
+export default stripSymbols;

--- a/test/test-utils/toEqualJson.d.ts
+++ b/test/test-utils/toEqualJson.d.ts
@@ -1,5 +1,0 @@
-declare namespace jasmine {
-  interface Matchers {
-    toEqualJson(expected: any): boolean;
-  }
-}

--- a/test/test-utils/toEqualJson.ts
+++ b/test/test-utils/toEqualJson.ts
@@ -1,35 +1,31 @@
-/// <reference path="./toEqualJson.d.ts" />
-// @see https://github.com/fluffynuts/polymer-ts-scratch/blob/master/src/specs/test-utils/jasmine-matchers/polymer-matchers.d.ts
-(function() {
-  function failWith(message) {
+declare namespace jest {
+  interface Matchers<R> {
+    toEqualJson(expected: any): R;
+  }
+}
+
+/**
+ * Apollo-client adds Symbols to the data in the store. In order to make
+ * assertions easier the toEqualJson method is used to strip a data object of any
+ * Symbols and then run an equal check on the stripped object.
+ */
+const toEqualJson = (received: any, expected: any) => {
+  try {
+    expect(JSON.parse(JSON.stringify(received))).toEqual(expected);
+    return {
+      pass: true,
+      // TODO: This method fails if we call expect(received).not.toEqualJson(expected)
+      // because there is no message yet.
+      message: () => '',
+    };
+  } catch (e) {
     return {
       pass: false,
-      message: message,
+      message: () => e,
     };
   }
+};
 
-  function doAssertions(logicFunc) {
-    try {
-      logicFunc();
-      return { pass: true };
-    } catch (e) {
-      return failWith(e.toString());
-    }
-  }
-
-  beforeAll(() => {
-    jasmine.addMatchers({
-      toEqualJson: function(): // util: jasmine.MatchersUtil,
-      // customEqualityTesters: Array<jasmine.CustomEqualityTester>,
-      jasmine.CustomMatcher {
-        return {
-          compare: function(actual: any, expected: any) {
-            return doAssertions(() => {
-              expect(JSON.parse(JSON.stringify(actual))).toEqual(expected);
-            });
-          },
-        };
-      },
-    });
-  });
-})();
+expect.extend({
+  toEqualJson,
+});

--- a/test/test-utils/toMatchSnapshot.d.ts
+++ b/test/test-utils/toMatchSnapshot.d.ts
@@ -1,6 +1,0 @@
-// @rosskevin - no idea why it wouldn't find the jest matcher
-declare namespace jasmine {
-  interface Matchers {
-    toMatchSnapshot(): boolean;
-  }
-}


### PR DESCRIPTION
This PR fixes the typescript issues in the project. 

I removed the `@types/jasmine`, this allowed me to remove`toMatchSnapshot.d.ts`.

The `toEqualJson` matcher is now also recognised in the matchers. This matchers also did not work, crashing when the assertion failed. I have tried to fix this but it turns out that defining a matchers in terms of another matcher is not supported by Jest, see [issue](https://github.com/facebook/jest/issues/2547). This means that writing `expect(received).not.toEqualJson(expected)` does not work. Instead I think I have found a much simpler solution, a `stripSymbol` function that simply removes all the symbols from an object, this can then be used to run assertions using `toEqual`. I have converted one test to use this method in order to get feedback. One thing I like about `stripSymbols` is that it makes the purpose of the function very clear compared to `toEqualJson` which may leave readers a bit confused as to the reason of this matcher.

I also noticed that we are not running type checks in the CI, this should be turned on in a follow-up PR.