### PR TITLE
Fix for flaky polling tests

### DIFF
--- a/test/react-web/client/Query.test.js
+++ b/test/react-web/client/Query.test.js
@@ -35,6 +35,10 @@ const catchAsyncError = (done, cb) => {
 };
 
 describe('Query component', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
   it('calls the children prop', done => {
     const Component = () => (
       <Query query={query}>
@@ -515,7 +519,6 @@ describe('Query component', () => {
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);
       wrapper.unmount();
-      jest.useRealTimers();
       done();
     });
   });
@@ -586,7 +589,6 @@ describe('Query component', () => {
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);
       wrapper.unmount();
-      jest.useRealTimers();
       done();
     });
   });
@@ -647,7 +649,6 @@ describe('Query component', () => {
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);
       wrapper.unmount();
-      jest.useRealTimers();
       done();
     });
   });

--- a/test/react-web/client/Query.test.js
+++ b/test/react-web/client/Query.test.js
@@ -592,12 +592,15 @@ describe('Query component', () => {
   });
 
   it('provides stopPolling in the render prop', done => {
+    jest.useFakeTimers();
     expect.assertions(3);
 
+    const POLL_COUNT = 2;
+    const POLL_TIME = 30;
     let count = 0;
 
     const Component = () => (
-      <Query query={query} pollInterval={30}>
+      <Query query={query} pollInterval={POLL_TIME}>
         {result => {
           if (result.loading) {
             return null;
@@ -639,13 +642,14 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    setTimeout(() => {
-      catchAsyncError(done, () => {
-        expect(count).toBe(2);
-        wrapper.unmount();
-        done();
-      });
-    }, 100);
+    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+
+    catchAsyncError(done, () => {
+      expect(count).toBe(POLL_COUNT);
+      wrapper.unmount();
+      jest.useRealTimers();
+      done();
+    });
   });
 
   it('provides updateQuery render prop', done => {

--- a/test/react-web/client/Query.test.js
+++ b/test/react-web/client/Query.test.js
@@ -517,10 +517,15 @@ describe('Query component', () => {
   });
 
   it('provides startPolling in the render prop', done => {
+    jest.useFakeTimers();
     expect.assertions(4);
 
     let count = 0;
     let isPolling = false;
+
+    const POLL_TIME = 30;
+    const POLL_COUNT = 3;
+
     const Component = () => (
       <Query query={query}>
         {result => {
@@ -529,7 +534,7 @@ describe('Query component', () => {
           }
           if (!isPolling) {
             isPolling = true;
-            result.startPolling(30);
+            result.startPolling(POLL_TIME);
           }
           catchAsyncError(done, () => {
             if (count === 0) {
@@ -572,13 +577,14 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    setTimeout(() => {
-      catchAsyncError(done, () => {
-        expect(count).toBe(3);
-        wrapper.unmount();
-        done();
-      });
-    }, 80);
+    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+
+    catchAsyncError(done, () => {
+      expect(count).toBe(POLL_COUNT);
+      wrapper.unmount();
+      jest.useRealTimers();
+      done();
+    });
   });
 
   it('provides stopPolling in the render prop', done => {

--- a/test/react-web/client/Query.test.js
+++ b/test/react-web/client/Query.test.js
@@ -459,12 +459,15 @@ describe('Query component', () => {
   });
 
   it('sets polling interval using options', done => {
+    jest.useFakeTimers();
     expect.assertions(4);
 
     let count = 0;
+    const POLL_COUNT = 3;
+    const POLL_TIME = 30;
 
     const Component = () => (
-      <Query query={query} pollInterval={30}>
+      <Query query={query} pollInterval={POLL_TIME}>
         {result => {
           if (result.loading) {
             return null;
@@ -507,13 +510,14 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    setTimeout(() => {
-      catchAsyncError(done, () => {
-        expect(count).toBe(3);
-        wrapper.unmount();
-        done();
-      });
-    }, 80);
+    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+
+    catchAsyncError(done, () => {
+      expect(count).toBe(POLL_COUNT);
+      wrapper.unmount();
+      jest.useRealTimers();
+      done();
+    });
   });
 
   it('provides startPolling in the render prop', done => {

--- a/test/react-web/client/Query.test.js
+++ b/test/react-web/client/Query.test.js
@@ -468,10 +468,10 @@ describe('Query component', () => {
 
     let count = 0;
     const POLL_COUNT = 3;
-    const POLL_TIME = 30;
+    const POLL_INTERVAL = 30;
 
     const Component = () => (
-      <Query query={query} pollInterval={POLL_TIME}>
+      <Query query={query} pollInterval={POLL_INTERVAL}>
         {result => {
           if (result.loading) {
             return null;
@@ -514,7 +514,7 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+    jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
 
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);
@@ -530,7 +530,7 @@ describe('Query component', () => {
     let count = 0;
     let isPolling = false;
 
-    const POLL_TIME = 30;
+    const POLL_INTERVAL = 30;
     const POLL_COUNT = 3;
 
     const Component = () => (
@@ -541,7 +541,7 @@ describe('Query component', () => {
           }
           if (!isPolling) {
             isPolling = true;
-            result.startPolling(POLL_TIME);
+            result.startPolling(POLL_INTERVAL);
           }
           catchAsyncError(done, () => {
             if (count === 0) {
@@ -584,7 +584,7 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+    jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
 
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);
@@ -598,11 +598,11 @@ describe('Query component', () => {
     expect.assertions(3);
 
     const POLL_COUNT = 2;
-    const POLL_TIME = 30;
+    const POLL_INTERVAL = 30;
     let count = 0;
 
     const Component = () => (
-      <Query query={query} pollInterval={POLL_TIME}>
+      <Query query={query} pollInterval={POLL_INTERVAL}>
         {result => {
           if (result.loading) {
             return null;
@@ -644,7 +644,7 @@ describe('Query component', () => {
       </MockedProvider>,
     );
 
-    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+    jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
 
     catchAsyncError(done, () => {
       expect(count).toBe(POLL_COUNT);

--- a/test/react-web/client/graphql/queries/polling.test.tsx
+++ b/test/react-web/client/graphql/queries/polling.test.tsx
@@ -20,7 +20,7 @@ describe('[queries] polling', () => {
   it('allows a polling query to be created', done => {
     jest.useFakeTimers();
 
-    const POLL_TIME = 250;
+    const POLL_INTERVAL = 250;
     const POLL_COUNT = 4;
     const query = gql`
       query people {
@@ -46,7 +46,7 @@ describe('[queries] polling', () => {
     let count = 0;
     const Container = graphql(query, {
       options: () => ({
-        pollInterval: POLL_TIME,
+        pollInterval: POLL_INTERVAL,
         notifyOnNetworkStatusChange: false,
       }),
     })(() => {
@@ -60,7 +60,7 @@ describe('[queries] polling', () => {
       </ApolloProvider>,
     );
 
-    jest.runTimersToTime(POLL_TIME * POLL_COUNT);
+    jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
 
     try {
       expect(count).toEqual(POLL_COUNT);

--- a/test/react-web/client/graphql/queries/polling.test.tsx
+++ b/test/react-web/client/graphql/queries/polling.test.tsx
@@ -11,7 +11,6 @@ describe('[queries] polling', () => {
   beforeEach(() => {
     error = console.error;
     console.error = jest.fn(() => {}); // tslint:disable-line
-    jest.useRealTimers();
   });
   afterEach(() => {
     console.error = error;
@@ -69,6 +68,7 @@ describe('[queries] polling', () => {
       done.fail(e);
     } finally {
       (wrapper as any).unmount();
+      jest.useRealTimers();
     }
   });
 

--- a/test/react-web/client/graphql/queries/polling.test.tsx
+++ b/test/react-web/client/graphql/queries/polling.test.tsx
@@ -11,6 +11,7 @@ describe('[queries] polling', () => {
   beforeEach(() => {
     error = console.error;
     console.error = jest.fn(() => {}); // tslint:disable-line
+    jest.useRealTimers();
   });
   afterEach(() => {
     console.error = error;
@@ -68,7 +69,6 @@ describe('[queries] polling', () => {
       done.fail(e);
     } finally {
       (wrapper as any).unmount();
-      jest.useRealTimers();
     }
   });
 


### PR DESCRIPTION
After pulling master I observed that some tests related to polling functionality were failing intermittently. After a discussion with @rosskevin he pointed me in the direction of a timing workaround in `polling.test.tsx` which needed firming up.

Rather than relying on magic numbers for timing intervals it seems to be more sensible to take full control of advancing the timers ourselves. Fortunately [Jest provides an API for doing this](http://facebook.github.io/jest/docs/en/timer-mocks.html) and we can manually advance time as required. This should make the tests deterministic.

Note that `jest.runTimersToTime` has been renamed to `jest.advanceTimersByTime` in v22.0.0.

I think I may have another pass at this to rename some of the test variables as its actually the render count we are asserting on and not the number of polls that happened - although there's plenty of cohesion between the two.