### PR TITLE
Switch ApolloConsumer.test to tsx

### DIFF
--- a/test/react-web/client/ApolloConsumer.test.tsx
+++ b/test/react-web/client/ApolloConsumer.test.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
+import * as React from 'react';
 import ApolloClient from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 import { ApolloLink } from 'apollo-link';
-
 import ApolloProvider from '../../../src/ApolloProvider';
 import ApolloConsumer from '../../../src/ApolloConsumer';
 import { mount } from 'enzyme';
-import invariant from 'invariant';
 
 const client = new ApolloClient({
   cache: new Cache(),
@@ -32,7 +30,7 @@ describe('<ApolloConsumer /> component', () => {
     );
   });
 
-  it('renders the content in the render prop', () => {
+  it('renders the content in the children prop', () => {
     const wrapper = mount(
       <ApolloProvider client={client}>
         <ApolloConsumer>{clientRender => <div />}</ApolloConsumer>
@@ -45,9 +43,9 @@ describe('<ApolloConsumer /> component', () => {
   it('errors if there is no client in the context', () => {
     // Prevent Error about missing context type from appearing in the console.
     const errorLogger = console.error;
-    console.error = () => {};
+    console.error = () => {}; // tslint:disable-line
     expect(() => {
-      mount(<ApolloConsumer render={client => null} />);
+      mount(<ApolloConsumer>{() => null}</ApolloConsumer>);
     }).toThrowError(
       'Could not find "client" in the context of ApolloConsumer. Wrap the root component in an <ApolloProvider>',
     );


### PR DESCRIPTION
`ApolloConsumer.test.js` is now `ApolloConsumer.test.tsx`