### PR TITLE
Fix TypeScript test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "danger": "danger run --verbose",
     "deploy": "./scripts/prepare-package.sh && cd npm && npm publish",
     "test": "npm run lint && npm run type-check && npm run testonly",
-    "testonly": "jest --maxWorkers=4",
+    "testonly": "jest --maxWorkers=4 --coverage",
     "test-watch": "jest --watch",
     "filesize": "bundlesize",
     "type-check": "tsc --project tsconfig.json --noEmit && flow check",
@@ -60,6 +60,7 @@
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!(lodash-es|react-native)/)"
     ],
+    "mapCoverage": true,
     "moduleFileExtensions": ["ts", "tsx", "js", "json"],
     "modulePathIgnorePatterns": [
       "<rootDir>/examples",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "danger": "danger run --verbose",
     "deploy": "./scripts/prepare-package.sh && cd npm && npm publish",
     "test": "npm run lint && npm run type-check && npm run testonly",
-    "testonly": "jest --maxWorkers=4 --coverage",
+    "testonly": "jest --maxWorkers=4",
     "test-watch": "jest --watch",
     "filesize": "bundlesize",
     "type-check": "tsc --project tsconfig.json --noEmit && flow check",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "danger": "danger run --verbose",
     "deploy": "./scripts/prepare-package.sh && cd npm && npm publish",
     "test": "npm run lint && npm run type-check && npm run testonly",
-    "testonly": "jest --maxWorkers=4",
+    "testonly": "jest --maxWorkers=4 --coverage",
     "test-watch": "jest --watch",
     "filesize": "bundlesize",
     "type-check": "tsc --project tsconfig.json --noEmit && flow check",


### PR DESCRIPTION
I was looking at the test coverage to see where any weaknesses lie in terms of missing test cases - I noticed that the reported missed lines weren't mapped to the actual locations.

If we add the [`mapCoverage` Jest option](http://facebook.github.io/jest/docs/en/configuration.html#mapcoverage-boolean) the coverage output now matches up to the correct lines so that we can start to identify any missing test cases.

**Before**

<img width="740" alt="screen shot 2017-12-27 at 17 56 11" src="https://user-images.githubusercontent.com/17656/34389075-67cae1ce-eb2f-11e7-8db8-b00689fac45a.png">

**After**

<img width="700" alt="screen shot 2017-12-27 at 17 54 43" src="https://user-images.githubusercontent.com/17656/34389027-10b08934-eb2f-11e7-91bc-454760c79ce0.png">
