### PR TITLE
Removed the variables from the render prop result in the Query.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ first three params (`TChildProps` can be derived). [#1402](https://github.com/ap
   - Removed react-native from the test suite [#1451](https://github.com/apollographql/react-apollo/pull/1451)
   - Add `client` to `Query`'s `QueryResult` [#1488](https://github.com/apollographql/react-apollo/pull/1488)
   - Disregard falsy elements when walking tree in SSR [#1495](https://github.com/apollographql/react-apollo/pull/1495)
+  - Removed the key `variables` from the render prop result in the `<Query />` [#1497](https://github.com/apollographql/react-apollo/pull/1497)
 
 ### 2.0.4
 - rolled back on the lodash-es changes from

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -22,7 +22,6 @@ const pick = require('lodash/pick');
 function observableQueryFields(observable) {
   const fields = pick(
     observable,
-    'variables',
     'refetch',
     'fetchMore',
     'updateQuery',
@@ -54,7 +53,6 @@ export interface QueryResult<TData = any> {
   updateQuery: (
     mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any,
   ) => void;
-  variables: OperationVariables;
 }
 
 export interface QueryProps {

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -161,54 +161,6 @@ describe('Query component', () => {
       );
     });
 
-    it('variables', done => {
-      const queryWithVariables = gql`
-        query people($first: Int) {
-          allPeople(first: $first) {
-            people {
-              name
-            }
-          }
-        }
-      `;
-
-      const mocksWithVariable = [
-        {
-          request: {
-            query: queryWithVariables,
-            // TODO: Currently, removing this variables field does not crash the test. We need to verify
-            // that the variables are included in the request.
-            variables: {
-              first: 1,
-            },
-          },
-          result: { data: allPeopleData },
-        },
-      ];
-
-      const variables = {
-        first: 1,
-      };
-
-      const Component = () => (
-        <Query query={queryWithVariables} variables={variables}>
-          {result => {
-            catchAsyncError(done, () => {
-              expect(result.variables).toEqual({ first: 1 });
-              done();
-            });
-            return null;
-          }}
-        </Query>
-      );
-
-      wrapper = mount(
-        <MockedProvider mocks={mocksWithVariable} removeTypename>
-          <Component />
-        </MockedProvider>,
-      );
-    });
-
     it('refetch', done => {
       const queryRefetch = gql`
         query people($first: Int) {
@@ -246,7 +198,7 @@ describe('Query component', () => {
       let count = 0;
       let hasRefetched = false;
 
-      expect.assertions(8);
+      expect.assertions(5);
 
       const Component = () => (
         <Query
@@ -255,7 +207,7 @@ describe('Query component', () => {
           notifyOnNetworkStatusChange
         >
           {result => {
-            const { data, loading, variables } = result;
+            const { data, loading } = result;
             if (loading) {
               count++;
               return null;
@@ -264,17 +216,14 @@ describe('Query component', () => {
             catchAsyncError(done, () => {
               if (count === 1) {
                 // first data
-                expect(variables).toEqual({ first: 1 });
                 expect(stripSymbols(data)).toEqual(data1);
               }
               if (count === 3) {
                 // second data
-                expect(variables).toEqual({ first: 1 });
                 expect(stripSymbols(data)).toEqual(data2);
               }
               if (count === 5) {
                 // third data
-                expect(variables).toEqual({ first: 2 });
                 expect(stripSymbols(data)).toEqual(data3);
               }
             });
@@ -331,7 +280,7 @@ describe('Query component', () => {
       ];
 
       let count = 0;
-      expect.assertions(3);
+      expect.assertions(2);
 
       const Component = () => (
         <Query query={allPeopleQuery} variables={variables}>
@@ -358,7 +307,6 @@ describe('Query component', () => {
                 .catch(done.fail);
             } else if (count === 1) {
               catchAsyncError(done, () => {
-                expect(result.variables).toEqual(variables);
                 expect(stripSymbols(result.data)).toEqual({
                   allPeople: {
                     people: [
@@ -812,11 +760,11 @@ describe('Query component', () => {
                 }
                 catchAsyncError(done, () => {
                   if (count === 0) {
-                    expect(result.variables).toEqual({ first: 1 });
+                    expect(variables).toEqual({ first: 1 });
                     expect(stripSymbols(result.data)).toEqual(data1);
                   }
                   if (count === 1) {
-                    expect(result.variables).toEqual({ first: 2 });
+                    expect(variables).toEqual({ first: 2 });
                     expect(stripSymbols(result.data)).toEqual(data2);
                     done();
                   }

--- a/test/client/__snapshots__/Query.test.tsx.snap
+++ b/test/client/__snapshots__/Query.test.tsx.snap
@@ -757,7 +757,6 @@ Object {
   "startPolling": [Function],
   "stopPolling": [Function],
   "updateQuery": [Function],
-  "variables": Object {},
 }
 `;
 
@@ -864,6 +863,5 @@ Object {
   "startPolling": [Function],
   "stopPolling": [Function],
   "updateQuery": [Function],
-  "variables": Object {},
 }
 `;


### PR DESCRIPTION
This PR removes the `variables` field in the result of the render prop in the `Query` component. The variable is already passed in the props of the component therefore there is no need to pass it in the render function.