### PR TITLE
fix(index.js.flow): fix options and errorPolicy types

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -45,11 +45,14 @@ export type ChildProps<P, R> = {
 // back compat
 export type DefaultChildProps<P, R> = ChildProps<P, R>;
 
+declare export type ErrorPolicy = 'none' | 'ignore' | 'all';
+
 export interface MutationOpts {
   variables?: Object;
   optimisticResponse?: Object;
   refetchQueries?: string[] | PureQueryOptions[];
   update?: MutationUpdaterFn<*>;
+  errorPolicy?: ErrorPolicy;
 }
 
 export interface QueryOpts {
@@ -58,6 +61,7 @@ export interface QueryOpts {
   fetchPolicy?: FetchPolicy;
   pollInterval?: number;
   skip?: boolean;
+  errorPolicy?: ErrorPolicy;
 }
 
 export interface GraphqlQueryControls {
@@ -83,14 +87,14 @@ export interface OptionProps<TProps, TResult> {
   mutate: MutationFunc<TResult>;
 }
 
-export type OptionDescription<P> = (props: P) => QueryOpts | MutationOpts;
+export type OptionDescription<P> = QueryOpts | MutationOpts | ((props: P) => QueryOpts | MutationOpts);
 
 export type NamedProps<P, R> = P & {
   ownProps: R,
 };
 
 export interface OperationOption<TProps: {}, TResult: {}> {
-  options?: OptionDescription<TProps>;
+  +options?: OptionDescription<TProps>;
   props?: (props: OptionProps<TProps, TResult>) => any;
   +skip?: boolean | ((props: any) => boolean);
   name?: string;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -45,7 +45,7 @@ export type ChildProps<P, R> = {
 // back compat
 export type DefaultChildProps<P, R> = ChildProps<P, R>;
 
-declare export type ErrorPolicy = 'none' | 'ignore' | 'all';
+export type ErrorPolicy = 'none' | 'ignore' | 'all';
 
 export interface MutationOpts {
   variables?: Object;


### PR DESCRIPTION
fixes two problems:
* def for `errorPolicy` option is missing
* the flow types required `options` to be a function returning the options,
  but it appears `withApollo` can take a plain options object as well.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
