### PR TITLE
Alternative APIs discussed for Query component

### DIFF
--- a/examples/components/package.json
+++ b/examples/components/package.json
@@ -7,7 +7,7 @@
     "graphql": "^0.12.0",
     "graphql-tag": "^2.6.0",
     "react": "^16.2.0",
-    "react-apollo": "file:../..",
+    "react-apollo": "file:../../npm",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17"
   },

--- a/examples/components/src/App.js
+++ b/examples/components/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Query } from 'react-apollo';
+import { Query, QueryWith3Props, QueryWith4Props } from 'react-apollo';
 import gql from 'graphql-tag';
 
 export const HERO_QUERY = gql`
@@ -17,15 +17,25 @@ export const HERO_QUERY = gql`
 `;
 
 const Character = ({ episode }) => (
-  <Query
-    query={HERO_QUERY}
-    variables={{ episode }}
-    render={result => {
+  <Query query={HERO_QUERY} variables={{ episode }}>
+    {result => {
       if (result.loading) {
         return <div>Loading</div>;
       }
       if (result.error) {
-        return <h1>ERROR</h1>;
+        return (
+          <div>
+            <h1>ERROR</h1>
+            <pre>{result.error.message}</pre>
+            <button
+              onClick={() => {
+                result.refetch({ episode });
+              }}
+            >
+              Refetch
+            </button>
+          </div>
+        );
       }
       const { hero } = result.data;
       return (
@@ -46,16 +56,212 @@ const Character = ({ episode }) => (
                       </h6>
                     ),
                 )}
+              <button
+                onClick={() => {
+                  result.refetch();
+                }}
+              >
+                Refetch
+              </button>
+              <button
+                onClick={() => {
+                  result.refetch({ episode: 'FOOBAR' });
+                }}
+              >
+                Cause Error
+              </button>
             </div>
           )}
         </div>
       );
     }}
+  </Query>
+);
+
+const Character2 = ({ episode }) => (
+  <QueryWith4Props
+    query={HERO_QUERY}
+    variables={{ episode }}
+    renderLoading={() => <div>Loading</div>}
+    renderError={(error, { refetch }) => (
+      <div>
+        <h1>ERROR</h1>
+        <pre>{error.message}</pre>
+        <button
+          onClick={() => {
+            refetch({ episode });
+          }}
+        >
+          Refetch
+        </button>
+      </div>
+    )}
+    renderResult={({ hero }, { refetch }) => (
+      <div>
+        {hero && (
+          <div>
+            <h3>{hero.name}</h3>
+
+            {hero.friends &&
+              hero.friends.map(
+                friend =>
+                  friend && (
+                    <h6 key={friend.id}>
+                      {friend.name}:{' '}
+                      {friend.appearsIn
+                        .map(x => x && x.toLowerCase())
+                        .join(', ')}
+                    </h6>
+                  ),
+              )}
+            <button
+              onClick={() => {
+                refetch();
+              }}
+            >
+              Refetch
+            </button>
+            <button
+              onClick={() => {
+                refetch({ episode: 'FOOBAR' });
+              }}
+            >
+              Cause Error
+            </button>
+          </div>
+        )}
+      </div>
+    )}
+  />
+);
+
+const Character3 = ({ episode }) => (
+  <QueryWith3Props
+    query={HERO_QUERY}
+    variables={{ episode }}
+    renderLoading={() => <div>Loading</div>}
+    renderError={(error, { refetch }) => (
+      <div>
+        <h1>ERROR</h1>
+        <pre>{error.message}</pre>
+        <button
+          onClick={() => {
+            refetch({ episode });
+          }}
+        >
+          Refetch
+        </button>
+      </div>
+    )}
+    render={({ data: { hero }, refetch }) => (
+      <div>
+        {hero && (
+          <div>
+            <h3>{hero.name}</h3>
+
+            {hero.friends &&
+              hero.friends.map(
+                friend =>
+                  friend && (
+                    <h6 key={friend.id}>
+                      {friend.name}:{' '}
+                      {friend.appearsIn
+                        .map(x => x && x.toLowerCase())
+                        .join(', ')}
+                    </h6>
+                  ),
+              )}
+            <button
+              onClick={() => {
+                refetch();
+              }}
+            >
+              Refetch
+            </button>
+            <button
+              onClick={() => {
+                refetch({ episode: 'FOOBAR' });
+              }}
+            >
+              Cause Error
+            </button>
+          </div>
+        )}
+      </div>
+    )}
+  />
+);
+
+const Character4 = ({ episode }) => (
+  <QueryWith3Props
+    query={HERO_QUERY}
+    variables={{ episode }}
+    renderLoading={() => <div>Loading</div>}
+    render={({ data: { hero }, error, refetch }) =>
+      error ? (
+        <div>
+          <h1>ERROR</h1>
+          <pre>{error.message}</pre>
+          <button
+            onClick={() => {
+              refetch({ episode });
+            }}
+          >
+            Refetch
+          </button>
+        </div>
+      ) : (
+        <div>
+          {hero && (
+            <div>
+              <h3>{hero.name}</h3>
+
+              {hero.friends &&
+                hero.friends.map(
+                  friend =>
+                    friend && (
+                      <h6 key={friend.id}>
+                        {friend.name}:{' '}
+                        {friend.appearsIn
+                          .map(x => x && x.toLowerCase())
+                          .join(', ')}
+                      </h6>
+                    ),
+                )}
+              <button
+                onClick={() => {
+                  refetch();
+                }}
+              >
+                Refetch
+              </button>
+              <button
+                onClick={() => {
+                  refetch({ episode: 'FOOBAR' });
+                }}
+              >
+                Cause Error
+              </button>
+            </div>
+          )}
+        </div>
+      )
+    }
   />
 );
 
 export const App = () => (
   <div>
+    <h1>API with children render prop</h1>
     <Character episode="EMPIRE" />
+    <h1>API with renderLoading, renderError, renderResult and render props</h1>
+    <Character2 episode="EMPIRE" />
+    <h1>API with renderLoading, renderError, render (using all props)</h1>
+    <Character3 episode="EMPIRE" />
+    <h1>
+      API with renderLoading, renderError, render (using only renderLoading and
+      render)
+    </h1>
+    <Character4 episode="EMPIRE" />
   </div>
 );


### PR DESCRIPTION
This PR adds a couple alternative APIs as discussed in the contrib meeting to see which API is the one we want to go forward with respect to ease of use for simple use cases, ergonomics, and flexibility to accommodate to advanced use cases as well.

The alternative APIs are built on top of the current one since the one implemented right now is the most flexible one. If we settle with a different API than the base one, we will change the implementation to optimize for that API instead.

The PR modifies an example that exercises the `Query` component, and now does the same thing with the different APIs, to see how the same code looks with them.

We have 3 different APIs:

* `Query`: This is the one currently implemented, and has a single render prop (currently `children`, but there was a discussion about using `render` instead. Please comment below why you think this should change/stay as is) that receives the data, error, loading and other client methods to handle the entire lifecycle of the request in a single function. This is the most flexible option as you can do whatever you want inside this function, and you can handle any combination of these flags (having data while loading new data, having errors and data, loading and errors, just data, etc).
* `QueryWith3Props`: This was another API that was suggested. It provides 3 props, `renderLoading`, `renderError` and `render`. If just `render` is used, it behaves the same as `Query` with `children`: it is executed for each case in the lifecycle of the request. If `renderLoading` is also used, the `render` function will no longer be called when the loading flag is true, and `renderLoading` will be called instead. Same thing with `renderError`.
* `QueryWith4Props`: This variation provides 4 props: `renderLoading`, `renderError`, `renderResult` and `render`. This component is meant to be used either by passing the 3 props `renderLoading`, `renderError` and `renderResult`, or by only passing `render`. In the latter case, it behaves the same as `Query`. In the former case, `renderLoading` is called when the `loading` flag is true, `renderError` is called when there's an error, and `renderResult` is called otherwise (that is, when the data is there without any errors and without loading). If you attempt to use any invalid combination, for example, `render` with `renderLoading` or with any other prop, an error is shown in the console to warn about this and `render` is used.

Let me know if I misunderstood any of the API alternatives we discussed, or if there's something missing or wrong, and I'll update the PR. You can also use this to play around with the API.

Notes: 

* To make sure the latest react-apollo code is installed in the example app, first run the `./script/prepare-package.sh` script and then run `yarn` in the example app folder.
* @peggyrayzis let me know if what you had in mind for the `renderLoading` and `renderError` cases is correct here. I recall we talked about using `renderLoading` only for the initial load for example, but right now I'm just using `data.loading` which is not exactly that (fetchMore would cause the loading flag to be true while having data). If this should indeed be just the initial loading (networkStatus equal to 1 I assume?), what should we do about the other states?
* I found a bug (I think) where `refetch` doesn't trigger an update in the query component after an error has occurred. I will try and track this to see what's the issue. To reproduce you can click the "Cause Error" button, and then hit "refetch", and verify nothing happens (it should show the results again IIUC).

cc @peggyrayzis, @stubailo, @jbaxleyiii, @rosskevin, @excitement-engineer 