### PR TITLE
Only call fetchData on Apollo components

### DIFF
--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -138,7 +138,12 @@ function getQueriesFromTree<Cache>(
 
   walkTree(rootElement, rootContext, (element, instance, context) => {
     const skipRoot = !fetchRoot && element === rootElement;
-    if (instance && typeof instance.fetchData === 'function' && !skipRoot) {
+    if (
+      instance &&
+      typeof instance.fetchData === 'function' &&
+      instance.constructor.name === 'GraphQL' &&
+      !skipRoot
+    ) {
       const query = instance.fetchData();
       if (query) {
         queries.push({ query, element, context });

--- a/test/server/getDataFromTree.test.tsx
+++ b/test/server/getDataFromTree.test.tsx
@@ -883,6 +883,43 @@ describe('SSR', () => {
       });
     });
 
+    it("shouldn't call `fetchData` on components that are not apollo components", () => {
+      const query = gql`
+        {
+          currentUser {
+            firstName
+          }
+        }
+      `;
+      const link = mockSingleLink({
+        request: { query },
+        result: { data: { currentUser: { firstName: 'James' } } },
+        delay: 50,
+      });
+      const apolloClient = new ApolloClient({
+        link,
+        cache: new Cache({ addTypename: false }),
+      });
+
+      const mockFetchData = jest.fn();
+      class WrappedComponent extends React.Component {
+        fetchData = mockFetchData;
+        render() {
+          return null;
+        }
+      }
+
+      const app = (
+        <ApolloProvider client={apolloClient}>
+          <WrappedComponent />
+        </ApolloProvider>
+      );
+
+      return getDataFromTree(app).then(() => {
+        expect(mockFetchData).not.toHaveBeenCalled();
+      });
+    });
+
     it('should correctly handle SSR mutations', () => {
       const query = gql`
         {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Resolves #1571 .

When walking the tree on the server, `react-apollo` was calling `fetchData` on any component that had a function called `fetchData`. For me, this was problematic as I have other components with functions called `fetchData`. During SSR, those functions would be called erroneously and would often throw errors.

This PR adds a check to ensure a component is an apollo `GraphQL` component before calling `fetchData`. The check isn't 100% bulletproof since it depends on the class name which is not guaranteed to be used only by `react-apollo`. If anyone has a better suggestion, I would love to hear it :)

### Checklist:

- [x] Make sure all of the significant new logic is covered by tests
