### PR TITLE
Resuscribe after error in Query component

### DIFF
--- a/test/client/__snapshots__/Query.test.tsx.snap
+++ b/test/client/__snapshots__/Query.test.tsx.snap
@@ -25,9 +25,7 @@ Object {
 }
 `;
 
-exports[
-  `Query component calls the children prop: result in render prop while loading 1`
-] = `
+exports[`Query component calls the children prop: result in render prop while loading 1`] = `
 Object {
   "data": Object {},
   "error": undefined,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This PR ports the fix done in https://github.com/apollographql/react-apollo/pull/1531 to the `graphql` HoC into the new `Query` component. Also does the same for https://github.com/apollographql/react-apollo/issues/378.

Pinging @wdimiceli since I wrote the same method in `Query` slightly different and the test passed, so double checking with him. Particularly interested about the order of unsubscribing and subscribing to the new one, since I changed that to be able to reuse a method, and it seems it doesn't change the behavior.

Btw that looks like a "hacky" way to fix it, we should definitely find a way to fix this in apollo client (especially due to the lack of loading state in the fetch of the result after the error. See the test for more details).