### PR TITLE
Fix queryErrors in getDataFromTree

### DIFF
--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -169,8 +169,10 @@ export default function getDataFromTree(
   const mappedQueries = queries.map(({ query, element, context }) => {
     // we've just grabbed the query for element, so don't try and get it again
     return query
-      .then(_ => getDataFromTree(element, context, false))
-      .catch(e => errors.push(e));
+      .then(
+        _ => getDataFromTree(element, context, false),
+        e => errors.push(e)
+      );
   });
 
   // Run all queries. If there are errors, still wait for all queries to execute

--- a/test/server/getDataFromTree.test.tsx
+++ b/test/server/getDataFromTree.test.tsx
@@ -617,6 +617,71 @@ describe('SSR', () => {
       });
     });
 
+    it('should merge multiple errors thrown by queries', () => {
+      const idQuery = gql`
+        {
+          currentUser {
+            id
+          }
+        }
+      `;
+      const nameQuery = gql`
+        {
+          currentUser {
+            firstName
+          }
+        }
+      `;
+      const link = mockSingleLink(
+        {
+          request: { query: idQuery },
+          error: new Error('Failed to fetch ID'),
+          delay: 40,
+        },
+        {
+          request: { query: nameQuery },
+          error: new Error('Failed to fetch name'),
+          delay: 60,
+        }
+      );
+      const apolloClient = new ApolloClient({
+        link,
+        cache: new Cache({ addTypename: false }),
+      });
+
+      const withId = graphql(idQuery);
+      const withName = graphql(nameQuery);
+
+      const IdComponent = ({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.id}</div>
+      );
+      const NameComponent = ({ data }) => (
+        <div>{data.loading ? 'loading' : data.currentUser.firstName}</div>
+      );
+      const WrappedIdComponent = withId(IdComponent);
+      const WrappedNameComponent = withName(NameComponent);
+
+      const Page = () => (
+        <div>
+          <WrappedIdComponent />
+          <WrappedNameComponent />
+        </div>
+      );
+
+      const app = (
+        <ApolloProvider client={apolloClient}>
+          <Page />
+        </ApolloProvider>
+      );
+
+      return getDataFromTree(app).catch(e => {
+        expect(e).toBeTruthy();
+        expect(e.queryErrors.length).toEqual(2);
+        expect(e.queryErrors[0].message).toEqual('Network error: Failed to fetch ID');
+        expect(e.queryErrors[1].message).toEqual('Network error: Failed to fetch name');
+      });
+    });
+
     it('should correctly skip queries (deprecated)', () => {
       const query = gql`
         {


### PR DESCRIPTION
The code in `getDataFromTree` which tries to build a composite Error of all encountered query errors does not work correctly. The final error thrown from the Promise will have the right message, but `queryErrors` will only have one item – that points to the composite error itself:

    { Error: 3 errors were thrown when executing your GraphQL queries.
        at react-apollo.umd.js:763:19
        queryErrors: [ [Circular] ] }

Upon investigating, the `catch` within `queries.map` was catching the composite error thrown within the recursive call to `getDataFromTree`. It's dutifully pushed onto the local `errors`, and then its `queryErrors` property is overwritten within the `Promise.all` `then` handler.

Using the two-argument form of `then` instead of a `then`/`catch` pair solves the issue.