### PR TITLE
Rollback importing non esm packages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+* Rollback importing non esm packages. Fixes the previous broken version [#1621](https://github.com/apollographql/react-apollo/pull/1621)
+
 ### 2.1.0-beta.1
 
 * Stricter type checking in the codebase. [#1617](https://github.com/apollographql/react-apollo/pull/1617)

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -8,7 +8,7 @@
     "apollo-link-http": "^1.3.2",
     "graphql-tag": "^2.6.1",
     "react": "^16.2.0",
-    "react-apollo": "2.1.0-beta.0",
+    "react-apollo": "../../lib",
     "react-dom": "^16.2.0"
   },
   "devDependencies": {

--- a/examples/typescript/src/Character.tsx
+++ b/examples/typescript/src/Character.tsx
@@ -5,7 +5,7 @@ import {
   Episode,
 } from './__generated__/types';
 import { GetCharacter as QUERY } from './queries';
-import { Query, QueryResult } from 'react-apollo';
+import { Query } from 'react-apollo';
 
 class CharacterQuery extends Query<
   GetCharacterQuery,
@@ -16,11 +16,12 @@ export interface CharacterProps {
   episode: Episode;
 }
 
-export const Character: React.SFC<CharacterProps> = (props) => {
+export const Character: React.SFC<CharacterProps> = props => {
   const { episode } = props;
+
   return (
     <CharacterQuery query={QUERY} variables={{ episode }}>
-      {({ loading, data, error }: QueryResult<GetCharacterQuery>) => {
+      {({ loading, data, error }) => {
         if (loading) return <div>Loading</div>;
         if (error) return <h1>ERROR</h1>;
         if (!data) return <div>no data</div>;

--- a/src/ApolloConsumer.tsx
+++ b/src/ApolloConsumer.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import ApolloClient from 'apollo-client';
-import invariant from 'invariant';
+
+const invariant = require('invariant');
 
 export interface ApolloConsumerProps {
   children: (client: ApolloClient<any>) => React.ReactElement<any> | null;

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -3,7 +3,8 @@ import * as PropTypes from 'prop-types';
 import { Component } from 'react';
 import ApolloClient from 'apollo-client';
 import QueryRecyclerProvider from './QueryRecyclerProvider';
-import invariant from 'invariant';
+
+const invariant = require('invariant');
 
 export interface ApolloProviderProps<TCache> {
   client: ApolloClient<TCache>;

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -12,9 +12,10 @@ import { DocumentNode } from 'graphql';
 import { ZenObservable } from 'zen-observable-ts';
 import { OperationVariables } from './types';
 import { parser, DocumentType } from './parser';
-import pick from 'lodash/pick';
-import shallowEqual from 'fbjs/lib/shallowEqual';
-import invariant from 'invariant';
+
+const pick = require('lodash/pick');
+const shallowEqual = require('fbjs/lib/shallowEqual');
+const invariant = require('invariant');
 
 // Improved FetchMoreOptions type, need to port them back to Apollo Client
 export interface FetchMoreOptions<TData, TVariables> {

--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -8,7 +8,8 @@ import {
   ChildContextProvider,
 } from 'react';
 import ApolloClient from 'apollo-client';
-import assign from 'object-assign';
+
+const assign = require('object-assign');
 
 export interface Context<Cache> {
   client?: ApolloClient<Cache>;

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -18,11 +18,12 @@ import {
   MutateProps,
 } from './types';
 import { OperationVariables } from './index';
-import pick from 'lodash/pick';
-import assign from 'object-assign';
-import hoistNonReactStatics from 'hoist-non-react-statics';
-import shallowEqual from 'fbjs/lib/shallowEqual';
-import invariant from 'invariant';
+
+const pick = require('lodash/pick');
+const assign = require('object-assign');
+const hoistNonReactStatics = require('hoist-non-react-statics');
+const shallowEqual = require('fbjs/lib/shallowEqual');
+const invariant = require('invariant');
 
 const defaultMapPropsToOptions = () => ({});
 const defaultMapResultToProps: <P>(props: P) => P = props => props;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,7 +5,7 @@ import {
   OperationDefinitionNode,
 } from 'graphql';
 
-import invariant from 'invariant';
+const invariant = require('invariant');
 
 export enum DocumentType {
   Query,

--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { OperationOption } from './types';
 import ApolloConsumer from './ApolloConsumer';
 import { ApolloClient } from 'apollo-client';
-import assign from 'object-assign';
-import invariant from 'invariant';
-import hoistNonReactStatics from 'hoist-non-react-statics';
+
+const assign = require('object-assign');
+const invariant = require('invariant');
+const hoistNonReactStatics = require('hoist-non-react-statics');
 
 function getDisplayName<P>(WrappedComponent: React.ComponentType<P>) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/test/client/graphql/shared-operations.test.tsx
+++ b/test/client/graphql/shared-operations.test.tsx
@@ -14,7 +14,8 @@ import {
 } from '../../../src';
 import * as TestUtils from 'react-dom/test-utils';
 import { DocumentNode } from 'graphql';
-import compose from 'lodash/flowRight';
+
+const compose = require('lodash/flowRight');
 
 describe('shared operations', () => {
   describe('withApollo', () => {
@@ -508,7 +509,7 @@ describe('shared operations', () => {
         ),
       );
 
-      const ContainerWithData = enhanced(props => {
+      const ContainerWithData = enhanced((props: ShipsAndPeopleChildProps) => {
         const { people, ships } = props;
         expect(people).toBeTruthy();
         expect(people.loading).toBeTruthy();

--- a/test/test-utils/enzyme.ts
+++ b/test/test-utils/enzyme.ts
@@ -1,4 +1,4 @@
 import * as Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -8,7 +8,7 @@
     // "noImplicitAny": false,
     "strict": true,
     "outDir": "lib",
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "experimentalDecorators": true,
     "pretty": true,
     "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "noImplicitAny": false,
     "strict": true,
     "outDir": "lib",
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "experimentalDecorators": true,
     "pretty": true,
     "removeComments": true,


### PR DESCRIPTION
This PR rolls back the imports of non esm packages. This breaks the bundles as they try to import those and access their `default` property.