### PR TITLE
TASK: Provide errors to component when error Policy is "all"

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -369,7 +369,7 @@ export default function graphql<
 
         const resultProps = { [name]: defaultMapResultToProps(result) };
         if (hasErrors) {
-          resultProps.errors = errors;
+          resultProps.errors = newResult.errors;
         }
 
         return resultProps;

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -367,7 +367,9 @@ export default function graphql<
 
         if (mapResultToProps) return mapResultToProps(newResult);
 
-        const resultProps = { [name]: defaultMapResultToProps(result) };
+        const resultProps: any = {
+          [name]: defaultMapResultToProps(result)
+        };
         if (hasErrors) {
           resultProps.errors = newResult.errors;
         }

--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -355,12 +355,15 @@ export default function graphql<
           ownProps: this.props,
         };
 
-        const { errors } = this.queryObservable.currentResult();
-        const hasErrors = errors && errors.length > 0;
-        if (hasErrors) {
-          newResult.errors = errors;
-        }
+        let hasErrors = false;
+        if (this.queryObservable) {
+          const { errors } = this.queryObservable.currentResult();
+          hasErrors = errors && errors.length > 0;
 
+          if (hasErrors) {
+            newResult.errors = errors;
+          }
+        }
 
         if (mapResultToProps) return mapResultToProps(newResult);
 


### PR DESCRIPTION
The docs say that "any errors reported will come under an error prop along side the data returned from the cache or server."  (https://www.apollographql.com/docs/react/features/error-handling.html)

This PR will provide those errors to the component.

To make it work, another PR is mandatory: https://github.com/apollographql/apollo-client/pull/2956