### PR TITLE
Skip updateQuery for Mutations when client is specified

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -189,6 +189,10 @@ export default function graphql<
           this.queryObservable = null;
           this.previousData = {};
 
+          if (this.type === DocumentType.Mutation) {
+            return;
+          }
+
           this.updateQuery(nextProps);
           if (!this.shouldSkip(nextProps)) {
             this.subscribeToQuery();

--- a/test/react-web/client/graphql/mutations/index.test.tsx
+++ b/test/react-web/client/graphql/mutations/index.test.tsx
@@ -55,6 +55,48 @@ describe('[mutations]', () => {
     );
   });
 
+  it('binds a mutation to props when client option is specified', () => {
+    const query = gql`
+      mutation addPerson {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+    const data = { allPeople: { people: [{ name: 'Darth Wader' }] } };
+    const link = mockSingleLink({
+      request: { query },
+      result: { data },
+    });
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    const anotherClient = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    const ContainerWithData = graphql(query, {
+      options: () => ({
+        client: anotherClient
+      })
+    })(({ mutate }) => {
+      expect(mutate).toBeTruthy();
+      expect(typeof mutate).toBe('function');
+      return null;
+    });
+
+    renderer.create(
+      <ApolloProvider client={client}>
+          <ContainerWithData />
+      </ApolloProvider>,
+    );
+  });
+
   it('binds a mutation to custom props', () => {
     const query = gql`
       mutation addPerson {


### PR DESCRIPTION
This PR fixes the error behaviour when you try to specify `client` options on the mutation wrapped HoC. Skip the updateQuery and subscribeToQuery inside a function
when client option is passed to the mutation. It fixes initial query execution and failure that variables are not passed to the mutation query.

## Usecase:
Usage of different client for the HoC mutation component. 

```jsx
const CustomClient =  new ApolloClient({
  link,
  cache
})

export default graphql(gql`
  mutation addUser($userId: ID!) {
    addUser(userId: $userId) {
  }
`, {
  options: () => ({
    client: CustomClient
  })
})(Component)
```

## Actual Behaviour
`browser.js?7a6c:40 Uncaught Error: The operation 'addUser' wrapping 'Component' is expecting a variable: 'userId' but it was not found in the props passed to 'Apollo(Component)'
`

## Expected Behaviour
`It should mount a component without any error as mutation is not executed yet`
### Checklist: