### PR TITLE
allowed all options to be passed either in the props or as options in the mutate function

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -39,18 +39,22 @@ export declare type FetchResult<
   context?: C;
 };
 
-export declare type MutationOptions<TVariables = OperationVariables> = {
+export declare type MutationOptions<TData = any, TVariables = OperationVariables> = {
   variables?: TVariables;
+  optimisticResponse?: Object;
+  refetchQueries?: string[] | PureQueryOptions[];
+  update?: MutationUpdaterFn<TData>;
 };
 
 export interface MutationProps<TData = any, TVariables = OperationVariables> {
   mutation: DocumentNode;
   optimisticResponse?: Object;
+  variables?: TVariables;
   refetchQueries?: string[] | PureQueryOptions[];
   update?: MutationUpdaterFn<TData>;
   children: (
     mutateFn: (
-      options?: MutationOptions<TVariables>,
+      options?: MutationOptions<TData, TVariables>,
     ) => Promise<void | FetchResult>,
     result?: MutationResult<TData>,
   ) => React.ReactNode;
@@ -161,16 +165,15 @@ class Mutation<
   };
 
   private mutate = (options: MutationOptions<TVariables>) => {
-    const { mutation, optimisticResponse, refetchQueries, update } = this.props;
-
-    const { variables } = options;
-
+    const { mutation, variables, optimisticResponse, refetchQueries, update } = this.props;
+    
     return this.client.mutate({
       mutation,
       variables,
       optimisticResponse,
       refetchQueries,
       update,
+      ...options
     });
   };
 


### PR DESCRIPTION
The `<Mutation />` component did not allow the user to pass all the options as input to the mutate function passed in the render prop (only variables could be passed). This PR allows the user to pass all the options either through the props or as a parameter in the mutate function.

**Note, any option that is passed in mutate function overrides those passed in the props. This behaviour is similar to how the `graphql` HOC currently does it**.

This PR is required to implement the `withMutation` HOC in PR #1688.