### PR TITLE
Remove unused dependency graphql-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "postcompile": "rollup -c  && ./scripts/prepare-package.sh",
     "watch": "tsc -w",
     "lint": "tslint --project tsconfig.json --config tslint.json",
-    "lint:fix": "npm run prettier && tslint 'src/*.ts*' --project tsconfig.json --fix",
+    "lint:fix":
+      "npm run prettier && tslint 'src/*.ts*' --project tsconfig.json --fix",
     "lint-staged": "lint-staged",
-    "prettier": "prettier --write \"{,!(node_modules|lib|coverage|npm)/**/}*.{ts*,js*,json,md}\""
+    "prettier":
+      "prettier --write \"{,!(node_modules|lib|coverage|npm)/**/}*.{ts*,js*,json,md}\""
   },
   "bundlesize": [
     {
@@ -43,15 +45,8 @@
     }
   ],
   "lint-staged": {
-    "*.{ts*}": [
-      "prettier --write",
-      "npm run lint",
-      "git add"
-    ],
-    "*.{js*,json,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{ts*}": ["prettier --write", "npm run lint", "git add"],
+    "*.{js*,json,md}": ["prettier --write", "git add"]
   },
   "repository": {
     "type": "git",
@@ -68,9 +63,7 @@
   ],
   "author": "James Baxley <james@meteor.com>",
   "babel": {
-    "presets": [
-      "env"
-    ]
+    "presets": ["env"]
   },
   "jest": {
     "testEnvironment": "jsdom",
@@ -79,25 +72,16 @@
       "^.+\\.jsx?$": "babel-jest"
     },
     "mapCoverage": true,
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
     "modulePathIgnorePatterns": [
       "<rootDir>/examples",
       "<rootDir>/test/flow-usage.js",
       "<rootDir>/test/typescript-usage.tsx",
       "<rootDir>/test/fail-no-entry-point.js"
     ],
-    "projects": [
-      "<rootDir>"
-    ],
+    "projects": ["<rootDir>"],
     "testRegex": "(/test/(?!test-utils\b)\b.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "setupFiles": [
-      "<rootDir>/test/test-utils/setup.ts"
-    ]
+    "setupFiles": ["<rootDir>/test/test-utils/setup.ts"]
   },
   "license": "MIT",
   "peerDependencies": {
@@ -158,7 +142,6 @@
   "dependencies": {
     "apollo-link": "^1.0.6",
     "fbjs": "^0.8.16",
-    "graphql-tag": "^2.7.0",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.2",
     "lodash": "4.17.5",

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -68,7 +68,7 @@ describe('Query component', () => {
 
             if (result.loading) {
               expect(rest).toMatchSnapshot(
-                'result in render prop while loading'
+                'result in render prop while loading',
               );
               expect(clientResult).toBe(client);
             } else {
@@ -85,7 +85,7 @@ describe('Query component', () => {
     wrapper = mount(
       <ApolloProvider client={client}>
         <Component />
-      </ApolloProvider>
+      </ApolloProvider>,
     );
   });
 
@@ -97,7 +97,7 @@ describe('Query component', () => {
     wrapper = mount(
       <MockedProvider mocks={allPeopleMocks} removeTypename>
         <Component />
-      </MockedProvider>
+      </MockedProvider>,
     );
     catchAsyncError(done, () => {
       expect(wrapper!.find('div').exists()).toBeTruthy();
@@ -148,7 +148,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocksWithVariable} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -168,7 +168,7 @@ describe('Query component', () => {
             }
             catchAsyncError(done, () => {
               expect(result.error).toEqual(
-                new Error('Network error: error occurred')
+                new Error('Network error: error occurred'),
               );
               done();
             });
@@ -180,7 +180,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mockError} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -279,7 +279,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -355,7 +355,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -417,7 +417,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
@@ -476,7 +476,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
@@ -538,7 +538,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
   });
@@ -562,7 +562,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={allPeopleMocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -614,7 +614,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -667,7 +667,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
 
       jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
@@ -696,10 +696,10 @@ describe('Query component', () => {
         mount(
           <MockedProvider>
             <Query query={mutation}>{() => null}</Query>
-          </MockedProvider>
+          </MockedProvider>,
         );
       }).toThrowError(
-        'The <Query /> component requires a graphql query, but got a mutation.'
+        'The <Query /> component requires a graphql query, but got a mutation.',
       );
 
       console.error = errorLogger;
@@ -722,10 +722,10 @@ describe('Query component', () => {
         mount(
           <MockedProvider>
             <Query query={subscription}>{() => null}</Query>
-          </MockedProvider>
+          </MockedProvider>,
         );
       }).toThrowError(
-        'The <Query /> component requires a graphql query, but got a subscription.'
+        'The <Query /> component requires a graphql query, but got a subscription.',
       );
 
       console.error = errorLogger;
@@ -808,7 +808,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -881,7 +881,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
 
@@ -1016,7 +1016,7 @@ describe('Query component', () => {
       wrapper = mount(
         <MockedProvider mocks={mocks} removeTypename>
           <Component />
-        </MockedProvider>
+        </MockedProvider>,
       );
     });
   });
@@ -1041,7 +1041,7 @@ describe('Query component', () => {
       componentDidCatch(error: any) {
         catchAsyncError(done, () => {
           const expectedError = new Error(
-            'The <Query /> component requires a graphql query, but got a subscription.'
+            'The <Query /> component requires a graphql query, but got a subscription.',
           );
           expect(error).toEqual(expectedError);
           console.error = errorLog;
@@ -1067,7 +1067,7 @@ describe('Query component', () => {
     wrapper = mount(
       <MockedProvider mocks={allPeopleMocks} removeTypename>
         <Component />
-      </MockedProvider>
+      </MockedProvider>,
     );
   });
 
@@ -1087,7 +1087,7 @@ describe('Query component', () => {
     const link = mockSingleLink(
       { request: { query }, result: { data } },
       { request: { query }, error: new Error('This is an error!') },
-      { request: { query }, result: { data: dataTwo } }
+      { request: { query }, result: { data: dataTwo } },
     );
     const client = new ApolloClient({
       link,
@@ -1117,7 +1117,7 @@ describe('Query component', () => {
                   // First result is loaded, run a refetch to get the second result
                   // which is an error.
                   expect(stripSymbols(result.data.allPeople)).toEqual(
-                    data.allPeople
+                    data.allPeople,
                   );
                   setTimeout(() => {
                     result.refetch().then(() => {
@@ -1155,7 +1155,7 @@ describe('Query component', () => {
                     break;
                   }
                   expect(stripSymbols(result.data.allPeople)).toEqual(
-                    dataTwo.allPeople
+                    dataTwo.allPeople,
                   );
                   done();
                   break;
@@ -1174,7 +1174,7 @@ describe('Query component', () => {
     wrapper = mount(
       <ApolloProvider client={client}>
         <Container />
-      </ApolloProvider>
+      </ApolloProvider>,
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,7 +1167,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1381,7 +1381,7 @@ commander@^2.11.0, commander@^2.9.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
-commander@^2.12.1, commander@^2.13.0:
+commander@^2.12.1, commander@^2.13.0, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
@@ -2212,10 +2212,6 @@ graphql-anywhere@^4.1.5:
   dependencies:
     apollo-utilities "^1.0.8"
 
-graphql-tag@2.7.3:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.7.3.tgz#5040112a1b4623285ef017c252276f0dea37f03f"
-
 graphql@0.11.7:
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
@@ -2574,6 +2570,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -4530,7 +4530,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -4591,6 +4591,28 @@ rollup-plugin-commonjs@8.3.0:
     resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-node-resolve@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.3.tgz#8f57b253edd00e5b0ad0aed7b7e9cf5982e98fa4"
+  dependencies:
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-plugin-replace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
+  dependencies:
+    magic-string "^0.22.4"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-uglify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz#a34eca24617709c6bf1778e9653baafa06099b86"
+  dependencies:
+    uglify-es "^3.3.7"
+
 rollup-pluginutils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
@@ -4598,9 +4620,9 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@0.56.1:
-  version "0.56.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.56.1.tgz#87dd6295103da48c2376872836273785ffe0def3"
+rollup@^0.56.1:
+  version "0.56.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.56.2.tgz#1788cf56d4350b6d8ecf76b5d654c59c7bf9c24a"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -4748,7 +4770,7 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -5089,6 +5111,13 @@ typescript@2.6.2, "typescript@>= 0.8.2":
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+uglify-es@^3.3.7:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
This PR removes graphql-tag from the dependencies. I think it was accidentally introduced in #1650.