### PR TITLE
[types] Allow function for refetchQueries, fix #1647

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -6,7 +6,7 @@ const invariant = require('invariant');
 import { DocumentNode, GraphQLError } from 'graphql';
 const shallowEqual = require('fbjs/lib/shallowEqual');
 
-import { OperationVariables } from './types';
+import { OperationVariables, RefetchQueriesProviderFn } from './types';
 import { parser, DocumentType } from './parser';
 
 export interface MutationResult<TData = Record<string, any>> {
@@ -46,7 +46,7 @@ export declare type MutationOptions<TVariables = OperationVariables> = {
 export interface MutationProps<TData = any, TVariables = OperationVariables> {
   mutation: DocumentNode;
   optimisticResponse?: Object;
-  refetchQueries?: string[] | PureQueryOptions[];
+  refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn;
   update?: MutationUpdaterFn<TData>;
   children: (
     mutateFn: (

--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -87,6 +87,7 @@ class Mutation<
     refetchQueries: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(PropTypes.object),
+      PropTypes.func,
     ]),
     update: PropTypes.func,
     children: PropTypes.func.isRequired,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -53,10 +53,14 @@ export type DefaultChildProps<P, R> = ChildProps<P, R, {}>;
 
 export type ErrorPolicy = 'none' | 'ignore' | 'all';
 
+export type RefetchQueriesProviderFn = (
+  ...args: any[]
+) => string[] | PureQueryOptions[];
+
 export type MutationOpts<TVariables> = {
   variables?: TVariables,
   optimisticResponse?: Object,
-  refetchQueries?: string[] | PureQueryOptions[],
+  refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
   update?: MutationUpdaterFn<*>,
   errorPolicy?: ErrorPolicy,
   $call?: empty, // Not function

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,13 +15,19 @@ export type OperationVariables = {
   [key: string]: any;
 };
 
+/**
+ * Function which returns an array of query names or query objects for refetchQueries option.
+ * Allows conditional refetches.
+ */
+export type RefetchQueriesProviderFn = (...args: any[]) => string[] | PureQueryOptions[];
+
 export interface MutationOpts<
   TData = any,
   TGraphQLVariables = OperationVariables
 > {
   variables?: TGraphQLVariables;
   optimisticResponse?: TData;
-  refetchQueries?: string[] | PureQueryOptions[];
+  refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn;
   update?: MutationUpdaterFn;
   client?: ApolloClient<any>;
   notifyOnNetworkStatusChange?: boolean;


### PR DESCRIPTION
fix #1647

Add ts and flow function type in refetchQueries mutate options.
I'm not familiar with flow, but the function type seems to be same as with typescript.