### PR TITLE
[types] Add errorPolicy to mutate options in ts types, fix #1486

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface MutationOpts<
 > {
   variables?: TGraphQLVariables;
   optimisticResponse?: TData;
+  errorPolicy?: ErrorPolicy;
   refetchQueries?: string[] | PureQueryOptions[];
   update?: MutationUpdaterFn;
   client?: ApolloClient<any>;


### PR DESCRIPTION
Fix #1486 for the mutate options part (for query options, it's already solved).

The flow types were already correct.