### PR TITLE
Add failing test for unmount component error

### DIFF
--- a/test/client/graphql/queries/errors.test.tsx
+++ b/test/client/graphql/queries/errors.test.tsx
@@ -535,20 +535,18 @@ describe('[queries] errors', () => {
     const query: DocumentNode = gql`
       query somethingelse {
         allPeople(first: 1) {
-          perople {
+          people {
             name
           }
         }
       }
     `;
     const data = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
-    const dataTwo = { allPeople: { people: [{ name: 'Princess Leia' }] } };
 
     type Data = typeof data;
     const link = mockSingleLink(
       { request: { query }, result: { data } },
       { request: { query }, error: new Error('This is an error!') },
-      { request: { query }, result: { data: dataTwo } },
     );
 
     const client = new ApolloClient({

--- a/test/client/graphql/queries/errors.test.tsx
+++ b/test/client/graphql/queries/errors.test.tsx
@@ -5,7 +5,14 @@ import ApolloClient from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 import { withState } from 'recompose';
 import { mockSingleLink } from '../../../../src/test-utils';
-import { ApolloProvider, graphql, ChildProps, Query, QueryResult } from '../../../../src';
+import {
+  ApolloProvider,
+  graphql,
+  ChildProps,
+  Query,
+  QueryResult,
+  DataValue,
+} from '../../../../src';
 
 import stripSymbols from '../../../test-utils/stripSymbols';
 import { DocumentNode } from 'graphql';
@@ -521,6 +528,113 @@ describe('[queries] errors', () => {
     renderer.create(
       <ApolloProvider client={client}>
         <Container />
+      </ApolloProvider>,
+    );
+  });
+  it('does not throw/console.err an error after a component that received a network error is unmounted', done => {
+    const query: DocumentNode = gql`
+      query somethingelse {
+        allPeople(first: 1) {
+          perople {
+            name
+          }
+        }
+      }
+    `;
+    const data = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
+    const dataTwo = { allPeople: { people: [{ name: 'Princess Leia' }] } };
+
+    type Data = typeof data;
+    const link = mockSingleLink(
+      { request: { query }, result: { data } },
+      { request: { query }, error: new Error('This is an error!') },
+      { request: { query }, result: { data: dataTwo } },
+    );
+
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+    let count = 0;
+    const noop = () => null;
+
+    interface ContainerOwnProps {
+      hideContainer: Function;
+    }
+
+    interface QueryChildProps {
+      data: DataValue<Data>;
+      hideContainer: Function;
+    }
+
+    const Container = graphql<ContainerOwnProps, Data, {}, QueryChildProps>(query, {
+      options: { notifyOnNetworkStatusChange: true },
+      props: something => {
+        return {
+          data: something.data!,
+          hideContainer: something!.ownProps.hideContainer,
+        };
+      },
+    })(
+      class extends React.Component<ChildProps<QueryChildProps, Data>> {
+        componentWillReceiveProps(props: ChildProps<QueryChildProps, Data>) {
+          try {
+            switch (count++) {
+              case 0:
+                props.data!
+                  .refetch()
+                  .then(() => {
+                    done.fail('Expected error value on first refetch.');
+                  })
+                  .catch(noop);
+                break;
+              case 2:
+                expect(props.data!.loading).toBeFalsy();
+                expect(props.data!.error).toBeTruthy();
+                const origError = console.error;
+                const errorMock = jest.fn();
+                console.error = errorMock;
+                props.hideContainer();
+                setTimeout(() => {
+                  expect(errorMock.mock.calls.length).toEqual(0);
+                  console.error = origError;
+                  done();
+                }, 100);
+                break;
+              default:
+                if (count < 2) {
+                  throw new Error('Unexpected fall through');
+                }
+            }
+          } catch (err) {
+            done.fail(err);
+          }
+        }
+        render() {
+          return null;
+        }
+      },
+    );
+
+    class Switcher extends React.Component<any, any> {
+      constructor(props: any) {
+        super(props);
+        this.state = {
+          showContainer: true,
+        };
+      }
+      render() {
+        const { state: { showContainer } } = this;
+        if (showContainer) {
+          return <Container hideContainer={() => this.setState({ showContainer: false })} />;
+        }
+        return null;
+      }
+    }
+
+    renderer.create(
+      <ApolloProvider client={client}>
+        <Switcher />
       </ApolloProvider>,
     );
   });


### PR DESCRIPTION
This adds a failing test for https://github.com/apollographql/apollo-client/issues/2258 and https://github.com/apollographql/apollo-client/issues/2797. (There might be more issues that are related to this).

The good news is that this test passes on the branch of #1715.

 @jbaxleyiii Should this be merged to avoid regressions?