### PR TITLE
Fix ApolloProvider import (fixes #1720)

### DIFF
--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ApolloClient from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 
-import { ApolloProvider } from '../src';
+import { ApolloProvider } from './';
 import { mockSingleLink } from './test-links';
 export * from './test-links';
 


### PR DESCRIPTION
This PR fixes the `../src` import problem for `ApolloProvider` in compiled `test-utils.js` detailed in #1720.