### PR TITLE
fix(Query): allow using default options from ApolloClient

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -52,6 +52,19 @@ export type ObservableQueryFields<TData, TVariables> = Pick<
   ) => void;
 };
 
+function compact(obj: any) {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      if (obj[key] !== undefined) {
+        acc[key] = obj[key];
+      }
+
+      return acc;
+    },
+    {} as any,
+  );
+}
+
 function observableQueryFields<TData, TVariables>(
   observable: ObservableQuery<TData>,
 ): ObservableQueryFields<TData, TVariables> {
@@ -228,6 +241,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
   }
 
   private extractOptsFromProps(props: QueryProps<TData, TVariables>) {
+    console;
     const {
       variables,
       pollInterval,
@@ -247,7 +261,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       }.`,
     );
 
-    return {
+    return compact({
       variables,
       pollInterval,
       query,
@@ -255,7 +269,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       errorPolicy,
       notifyOnNetworkStatusChange,
       metadata: { reactComponent: { displayName } },
-    };
+    });
   }
 
   private initializeQueryObservable(props: QueryProps<TData, TVariables>) {

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -241,7 +241,6 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
   }
 
   private extractOptsFromProps(props: QueryProps<TData, TVariables>) {
-    console;
     const {
       variables,
       pollInterval,

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -15,7 +15,11 @@ export class MockedProvider extends React.Component<any, any> {
 
     const addTypename = !this.props.removeTypename;
     const link = mockSingleLink.apply(null, this.props.mocks);
-    this.client = new ApolloClient({ link, cache: new Cache({ addTypename }) });
+    this.client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename }),
+      defaultOptions: this.props.defaultOptions,
+    });
   }
 
   render() {

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -553,6 +553,31 @@ describe('Query component', () => {
       );
     });
 
+    it('default fetch-policy', done => {
+      const Component = () => (
+        <Query query={allPeopleQuery}>
+          {result => {
+            catchAsyncError(done, () => {
+              expect(result.loading).toBeFalsy();
+              expect(result.networkStatus).toBe(NetworkStatus.ready);
+              done();
+            });
+            return null;
+          }}
+        </Query>
+      );
+
+      wrapper = mount(
+        <MockedProvider
+          defaultOptions={{ watchQuery: { fetchPolicy: 'cache-only' } }}
+          mocks={allPeopleMocks}
+          removeTypename
+        >
+          <Component />
+        </MockedProvider>,
+      );
+    });
+
     it('notifyOnNetworkStatusChange', done => {
       const data1 = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
       const data2 = { allPeople: { people: [{ name: 'Han Solo' }] } };


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Before, Query was passing options to `watchQuery` even if they were undefined. So, if we had { fetchQuery: undefined }, ApolloClient would not use the default because it is doing
Object.assign({}, defaults, { fetchPolicy: undefined }). So fetchPolicy would always be undefined

### Checklist:

~* If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)~
* [x] Make sure all of the significant new logic is covered by tests
~* If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.~
