### PR TITLE
ensure context is passed to links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * Fix default values being set as falsy in options merging
 * Remove console.error call for unhandled errors for query-hoc (but keep in place for graphql hoc for backwards compat)
+* Ensure context can be passed as props
 
 ### 2.1.0-beta.3
 

--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -59,6 +59,7 @@ export interface MutationProps<TData = any, TVariables = OperationVariables> {
   ) => React.ReactNode;
   onCompleted?: (data: TData) => void;
   onError?: (error: ApolloError) => void;
+  context?: Record<string, any>;
 }
 
 export interface MutationState<TData = any> {
@@ -161,7 +162,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
   };
 
   private mutate = (options: MutationOptions<TVariables>) => {
-    const { mutation, variables, optimisticResponse, update } = this.props;
+    const { mutation, variables, optimisticResponse, update, context = {} } = this.props;
     let refetchQueries = options.refetchQueries || this.props.refetchQueries;
     // XXX this will be removed in the 3.0 of Apollo Client. Currently, we
     // support refectching of named queries which just pulls the latest
@@ -185,6 +186,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
       optimisticResponse,
       refetchQueries,
       update,
+      context,
       ...options,
     });
   };

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -104,6 +104,7 @@ export interface QueryProps<TData = any, TVariables = OperationVariables> {
   displayName?: string;
   skip?: boolean;
   client?: ApolloClient<Object>;
+  context?: Record<string, any>;
 }
 
 export interface QueryContext {
@@ -186,8 +187,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     this.startQuerySubscription();
     if (this.refetcherQueue) {
       const { args, resolve, reject } = this.refetcherQueue;
-      this.queryObservable!
-        .refetch(args)
+      this.queryObservable!.refetch(args)
         .then(resolve)
         .catch(reject);
     }
@@ -249,6 +249,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       notifyOnNetworkStatusChange,
       query,
       displayName = 'Query',
+      context = {},
     } = props;
 
     this.operation = parser(query);
@@ -268,6 +269,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       errorPolicy,
       notifyOnNetworkStatusChange,
       metadata: { reactComponent: { displayName } },
+      context,
     });
   }
 
@@ -287,8 +289,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     // if we skipped initially, we may not have yet created the observable
     if (!this.queryObservable) this.initializeQueryObservable(props);
 
-    this.queryObservable!
-      .setOptions(this.extractOptsFromProps(props))
+    this.queryObservable!.setOptions(this.extractOptsFromProps(props))
       // The error will be passed to the child container, so we don't
       // need to log it here. We could conceivably log something if
       // an option was set. OTOH we don't log errors w/ the original

--- a/src/queryRecycler.ts
+++ b/src/queryRecycler.ts
@@ -108,7 +108,7 @@ export class ObservableQueryRecycler {
       // are set to `undefined` if not provided in options.
       pollInterval: options.pollInterval,
       fetchPolicy: options.fetchPolicy,
-    });
+    } as any);
 
     return observableQuery;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface MutationOpts<TData = any, TGraphQLVariables = OperationVariable
   update?: MutationUpdaterFn;
   client?: ApolloClient<any>;
   notifyOnNetworkStatusChange?: boolean;
+  context?: Record<string, any>;
 }
 
 export interface QueryOpts<TGraphQLVariables = OperationVariables> {
@@ -39,6 +40,7 @@ export interface QueryOpts<TGraphQLVariables = OperationVariables> {
   pollInterval?: number;
   client?: ApolloClient<any>;
   notifyOnNetworkStatusChange?: boolean;
+  context?: Record<string, any>;
 }
 
 export interface GraphqlQueryControls<TGraphQLVariables = OperationVariables> {

--- a/test/client/graphql/queries/index.test.tsx
+++ b/test/client/graphql/queries/index.test.tsx
@@ -644,7 +644,7 @@ describe('queries', () => {
     const link = new ApolloLink((o, f) => {
       expect(o.getContext().fromProps).toBe(true);
       done();
-      return f(o);
+      return f ? f(o) : null;
     }).concat(
       mockSingleLink({
         request: { query },

--- a/test/client/graphql/queries/index.test.tsx
+++ b/test/client/graphql/queries/index.test.tsx
@@ -666,9 +666,7 @@ describe('queries', () => {
 
     const ContainerWithData = graphql<any, Data>(query, {
       options: props => ({ context: { fromProps: props.context } }),
-    })(({ data }: DataProps<Data>) => {
-      return null;
-    });
+    })(() => null);
 
     renderer.create(
       <ApolloProvider client={client}>

--- a/test/client/graphql/queries/index.test.tsx
+++ b/test/client/graphql/queries/index.test.tsx
@@ -4,6 +4,7 @@ import * as renderer from 'react-test-renderer';
 import gql from 'graphql-tag';
 import ApolloClient from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
+import { ApolloLink, Observable } from 'apollo-link';
 import { mockSingleLink } from '../../../../src/test-utils';
 import { ApolloProvider, graphql, DataProps, ChildProps } from '../../../../src';
 
@@ -628,5 +629,51 @@ describe('queries', () => {
 
     // Not sure why I have to cast Container to any
     expect((Container as any).displayName).toEqual('withFoo(Container)');
+  });
+
+  it('passes context to the link', done => {
+    const query: DocumentNode = gql`
+      query people {
+        allPeople(first: 1) {
+          people {
+            name
+          }
+        }
+      }
+    `;
+    const link = new ApolloLink((o, f) => {
+      expect(o.getContext().fromProps).toBe(true);
+      done();
+      return f(o);
+    }).concat(
+      mockSingleLink({
+        request: { query },
+        result: {
+          data: { allPeople: { people: [{ name: 'Luke Skywalker' }] } },
+        },
+      }),
+    );
+    const client = new ApolloClient({
+      link,
+      cache: new Cache({ addTypename: false }),
+    });
+
+    interface Data {
+      allPeople?: {
+        people: { name: string }[];
+      };
+    }
+
+    const ContainerWithData = graphql<any, Data>(query, {
+      options: props => ({ context: { fromProps: props.context } }),
+    })(({ data }: DataProps<Data>) => {
+      return null;
+    });
+
+    renderer.create(
+      <ApolloProvider client={client}>
+        <ContainerWithData context={true} />
+      </ApolloProvider>,
+    );
   });
 });


### PR DESCRIPTION
With the refactor, I removed an untested path of passing a custom context to the link chain. Added smoke test and fixed