### PR TITLE
Fixed inconsistency in naming of the prop for the subscription

### DIFF
--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -42,7 +42,7 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
   };
 
   static propTypes = {
-    query: PropTypes.object.isRequired,
+    subscription: PropTypes.object.isRequired,
     variables: PropTypes.object,
     children: PropTypes.func.isRequired,
   };

--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -17,7 +17,7 @@ export interface SubscriptionResult<TData = any> {
 }
 
 export interface SubscriptionProps<TData = any, TVariables = OperationVariables> {
-  query: DocumentNode;
+  subscription: DocumentNode;
   variables?: TVariables;
   shouldResubscribe?: boolean;
   children: (result: SubscriptionResult<TData>) => React.ReactNode;
@@ -105,7 +105,7 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
   private initialize = (props: SubscriptionProps<TData, TVariables>) => {
     if (this.queryObservable) return;
     this.queryObservable = this.client.subscribe({
-      query: props.query,
+      query: props.subscription,
       variables: props.variables,
     });
   };

--- a/src/subscription-hoc.tsx
+++ b/src/subscription-hoc.tsx
@@ -76,7 +76,7 @@ export function subscribe<
             {...opts}
             displayName={graphQLDisplayName}
             skip={shouldSkip}
-            query={document}
+            subscription={document}
             shouldResubscribe={this.state.resubscribe}
           >
             {({ data, ...r }) => {

--- a/test/client/Subscription.test.tsx
+++ b/test/client/Subscription.test.tsx
@@ -49,7 +49,7 @@ it('executes the subscription', done => {
   let count = 0;
 
   const Component = () => (
-    <Subscription query={subscription}>
+    <Subscription subscription={subscription}>
       {result => {
         const { loading, data, error } = result;
 
@@ -129,7 +129,7 @@ it('executes subscription for the variables passed in the props', done => {
   let count = 0;
 
   const Component = () => (
-    <Subscription query={subscriptionWithVariables} variables={variables}>
+    <Subscription subscription={subscriptionWithVariables} variables={variables}>
       {result => {
         const { loading, data } = result;
 
@@ -176,7 +176,7 @@ it('renders an error', done => {
 
   let count = 0;
   const Component = () => (
-    <Subscription query={subscriptionWithVariables} variables={variables}>
+    <Subscription subscription={subscriptionWithVariables} variables={variables}>
       {result => {
         const { loading, data, error } = result;
         catchAsyncError(done, () => {
@@ -224,7 +224,7 @@ describe('should update', () => {
       render() {
         return (
           <ApolloProvider client={this.state.client}>
-            <Subscription query={subscription}>
+            <Subscription subscription={subscription}>
               {result => {
                 const { loading, data } = result;
                 catchAsyncError(done, () => {
@@ -309,7 +309,7 @@ describe('should update', () => {
 
       render() {
         return (
-          <Subscription query={this.state.subscription}>
+          <Subscription subscription={this.state.subscription}>
             {result => {
               const { loading, data } = result;
               catchAsyncError(done, () => {
@@ -421,7 +421,7 @@ describe('should update', () => {
 
       render() {
         return (
-          <Subscription query={subscriptionWithVariables} variables={this.state.variables}>
+          <Subscription subscription={subscriptionWithVariables} variables={this.state.variables}>
             {result => {
               const { loading, data } = result;
               catchAsyncError(done, () => {


### PR DESCRIPTION
There is an inconsistency in the names of the props for the documents:

```
<Query query={} />
<Mutation mutation={} />
<Subscription query={} />
```

The name of the prop for the `Subscription` component is inconsistent with the others. Therefore, I propose that we call the prop `subscription` instead of `query`

```
<Subscription subscription={} />
```