### PR TITLE
Regression on 2.1.0-rc.3: refetchQueries throw errors on unknown queries

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -174,7 +174,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
     // refetch.
     if (refetchQueries && refetchQueries.length && Array.isArray(refetchQueries)) {
       refetchQueries = (refetchQueries as any).map((x: string | PureQueryOptions) => {
-        if (typeof x === 'string' && this.context.operations) return this.context.operations.get(x);
+        if (typeof x === 'string' && this.context.operations) return this.context.operations.get(x) || x;
         return x;
       });
       delete options.refetchQueries;


### PR DESCRIPTION
When we are searching a query to refetch, we must take care to return the operation, if it exists, else we must return the original string.
The code in apollo-client does not handle a query equal to "undefined" but takes care of the string if properly forwarded to. See [the related code L254](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/QueryManager.ts).

How to reproduce the bug:

- provide a unknown query as a string in the mutation options. (ex: refetchQueries: ['test'])
- Run the mutation
- Instead of ignoring the query as expected, Apollo with throw an error: **"Uncaught TypeError: Cannot read property 'query' of undefined at QueryManager.js:143"**