### PR TITLE
Fix to avoid unnecessary re-render

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -299,8 +299,13 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
 
   private startQuerySubscription = () => {
     if (this.querySubscription) return;
+    const initialQueryResult = this.getQueryResult();
     this.querySubscription = this.queryObservable!.subscribe({
-      next: this.updateCurrentData,
+      next: () => {
+        if (initialQueryResult.loading) {
+          this.updateCurrentData
+        }
+      },
       error: error => {
         this.resubscribeToQuery();
         // Quick fix for https://github.com/apollostack/react-apollo/issues/378

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -303,7 +303,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     this.querySubscription = this.queryObservable!.subscribe({
       next: () => {
         if (initialQueryResult.loading) {
-          this.updateCurrentData
+          this.updateCurrentData();
         }
       },
       error: error => {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR is an attempt to fix [unnecessary rerender issue](https://github.com/apollographql/react-apollo/issues/1777)
When data is queried from local-state, data is available in the first render itself and loading is not set to true. So second re-render is not necessary.
I added a check to avoid forceUpdate if loading is false initially.
Let me know if this approach is correct.

4 tests are failing with this PR. I am debugging them.
