### PR TITLE
Typing improvements for withApollo

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -19,6 +19,7 @@ export * from './Subscriptions';
 export { graphql } from './graphql';
 
 export { default as withApollo } from './withApollo';
+export * from './withApollo'
 
 export * from './types';
 

--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -12,7 +12,7 @@ function getDisplayName<P>(WrappedComponent: React.ComponentType<P>) {
 
 export type WithApolloClient<P> = P & { client: ApolloClient<any> };
 
-export default function withApollo<TProps, TResult>(
+export default function withApollo<TProps, TResult = any>(
   WrappedComponent: React.ComponentType<WithApolloClient<TProps>>,
   operationOptions: OperationOption<TProps, TResult> = {},
 ): React.ComponentClass<TProps> {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This exports the `WithApolloClient` type as a top-level export. Fixes #1816.

It also adds a default value for `withApollo`'s `TResult` parameter - it now defaults to `any`, for ease of use (e.g. if you're only using a mutation and don't care about the response [or the mutation always returns null] then there's no benefit in having to manually specify `any`).