### PR TITLE
Common typing example

### DIFF
--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import ApolloClient, { ApolloError } from 'apollo-client';
-import { Observable } from 'apollo-client/util/Observable';
+import { Observable } from 'apollo-link';
 
 import { DocumentNode } from 'graphql';
 import { ZenObservable } from 'zen-observable-ts';

--- a/test/client/graphql/queries/reducer.test.tsx
+++ b/test/client/graphql/queries/reducer.test.tsx
@@ -4,14 +4,14 @@ import gql from 'graphql-tag';
 import ApolloClient from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 import { mockSingleLink } from '../../../../src/test-utils';
-import { ApolloProvider, graphql } from '../../../../src';
+import { ApolloProvider, graphql, DataValue } from '../../../../src';
 
 import stripSymbols from '../../../test-utils/stripSymbols';
 import { DocumentNode } from 'graphql';
 
 describe('[queries] reducer', () => {
   // props reducer
-  it('allows custom mapping of a result to props', () => {
+  it('allows custom mapping of a result to props', done => {
     const query: DocumentNode = gql`
       query thing {
         getThing {
@@ -19,30 +19,28 @@ describe('[queries] reducer', () => {
         }
       }
     `;
-    const data = { getThing: { thing: true } };
+    const result = { getThing: { thing: true } };
     const link = mockSingleLink({
       request: { query },
-      result: { data },
+      result: { data: result },
     });
     const client = new ApolloClient({
       link,
       cache: new Cache({ addTypename: false }),
     });
 
-    interface Data {
-      getThing: { thing: boolean };
-    }
+    type Data = typeof result;
+    // in case of a skip
+    type ChildProps = DataValue<Data>;
 
-    interface FinalProps {
-      showSpinner: boolean | undefined;
-    }
-
-    const ContainerWithData = graphql<{}, Data, {}, FinalProps>(query, {
-      props: result => ({
-        showSpinner: result.data && result.data.loading,
-      }),
-    })(({ showSpinner }: FinalProps) => {
-      expect(showSpinner).toBeTruthy();
+    const ContainerWithData = graphql<{}, Data, {}, ChildProps>(query, {
+      props: ({ data }) => ({ ...data! }),
+    })(({ getThing, loading }) => {
+      expect(loading).toBe(true);
+      if (!loading) {
+        expect(getThing).toBeDefined();
+        done();
+      }
       return null;
     });
 

--- a/test/client/graphql/queries/reducer.test.tsx
+++ b/test/client/graphql/queries/reducer.test.tsx
@@ -33,11 +33,13 @@ describe('[queries] reducer', () => {
     // in case of a skip
     type ChildProps = DataValue<Data>;
 
+    let count = 0;
     const ContainerWithData = graphql<{}, Data, {}, ChildProps>(query, {
       props: ({ data }) => ({ ...data! }),
     })(({ getThing, loading }) => {
-      expect(loading).toBe(true);
-      if (!loading) {
+      count++;
+      if (count === 1) expect(loading).toBe(true);
+      if (count === 2) {
         expect(getThing).toBeDefined();
         done();
       }
@@ -49,7 +51,6 @@ describe('[queries] reducer', () => {
         <ContainerWithData />
       </ApolloProvider>,
     );
-    (wrapper as any).unmount();
   });
 
   it('allows custom mapping of a result to props that includes the passed props', () => {


### PR DESCRIPTION
With the new types, its harder to do simple spreading of data which is pretty common. I've added a test for it and will update the ts guide accordingly

This also moves the Observable to be from AL which is what AC actually uses and makes developing with npm linked apollo-client much easier