### PR TITLE
Bring flow types back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
 
   Node.js 9:
     docker: [ { image: 'circleci/node:9' } ]
-    steps: 
+    steps:
       - checkout
-      - run: npm i 
+      - run: npm i
       - run:
           name: Jest suite
           command: npm run jest -- --ci --testResultsProcessor="jest-junit"
@@ -48,6 +48,7 @@ jobs:
       - checkout
       - run: npm i
       - run: npm run type-check
+      - run: npm run flow-check
 
   Preact:
     docker: [ { image: 'circleci/node:8' } ]
@@ -131,7 +132,7 @@ workflows:
       - Node.js 8
       - Node.js 9
       - Linting
-      - Typecheck 
+      - Typecheck
       - Preact
       - Browser
       - Server

--- a/.flowconfig
+++ b/.flowconfig
@@ -4,9 +4,14 @@
 .*/node_modules/art/.*
 .*/node_modules/react-native/**/.*
 
+[untyped]
+.*/node_modules/graphql/.*
+
 [include]
 
 [libs]
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$ExpectError
+; needed for $ExpectError to actually work
+include_warnings=true

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:compiled:cjs": "jest --config jest.cjs.config.js --runInBand",
     "test:compiled:server:umd": "jest --config jest.server.umd.config.js --runInBand",
     "type-check": "tsc --project tsconfig.json --noEmit ",
+    "flow-check": "flow check test",
     "watch": "tsc -w"
   },
   "babel": {

--- a/scripts/prepare-package.sh
+++ b/scripts/prepare-package.sh
@@ -31,4 +31,5 @@ node -e "var package = require('./package.json'); \
 # Copy few more files to ./lib
 cp README.md lib/
 cp LICENSE lib/
+cp src/index.js.flow lib/
 cp .npmignore lib/

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,199 @@
+// @flow
+import type {
+  ApolloClient,
+  MutationQueryReducersMap,
+  ApolloQueryResult,
+  ApolloError,
+  FetchPolicy,
+  FetchMoreOptions,
+  UpdateQueryOptions,
+  FetchMoreQueryOptions,
+  SubscribeToMoreOptions,
+  PureQueryOptions,
+  MutationUpdaterFn,
+} from 'apollo-client';
+import type { DocumentNode, VariableDefinitionNode } from 'graphql';
+
+export type NetworkStatus = 1 | 2 | 3 | 4 | 6 | 7 | 8;
+
+export interface ProviderProps {
+  client: ApolloClient;
+}
+
+declare export class ApolloProvider extends React$Component<ProviderProps> {
+  childContextTypes: {
+    client: ApolloClient,
+  };
+  contextTypes: {
+    client: ApolloClient,
+  };
+  getChildContext(): {
+    client: ApolloClient,
+  };
+  render(): React$Element<*>;
+}
+
+export type MutationFunc<TResult, TVariables> = (
+  opts: MutationOpts<TVariables>,
+) => Promise<ApolloQueryResult<TResult>>;
+
+export type GraphqlData<TResult, TVariables> = GraphqlQueryControls &
+  TResult & {
+    variables: TVariables,
+    refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>,
+  };
+
+export type ChildProps<TOwnProps, TResult, TVariables: Object = {}> = {
+  data: GraphqlData<TResult, TVariables>,
+  mutate: MutationFunc<TResult, TVariables>,
+} & TOwnProps;
+
+// back compat
+export type DefaultChildProps<P, R> = ChildProps<P, R, {}>;
+
+export type ErrorPolicy = 'none' | 'ignore' | 'all';
+
+export type RefetchQueriesProviderFn = (
+  ...args: any[]
+) => string[] | PureQueryOptions[];
+
+export type MutationOpts<TVariables> = {
+  variables?: TVariables,
+  optimisticResponse?: Object,
+  refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
+  update?: MutationUpdaterFn<*>,
+  errorPolicy?: ErrorPolicy,
+  $call?: empty, // Not function
+};
+
+export type QueryOpts<TVariables> = {
+  ssr?: boolean,
+  variables?: TVariables,
+  fetchPolicy?: FetchPolicy,
+  pollInterval?: number,
+  skip?: boolean,
+  errorPolicy?: ErrorPolicy,
+  $call?: empty, // Not function
+};
+
+export interface GraphqlQueryControls {
+  error?: ApolloError;
+  networkStatus: NetworkStatus;
+  loading: boolean;
+  variables: Object;
+  fetchMore: (
+    fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions,
+  ) => Promise<ApolloQueryResult<any>>;
+  refetch: (variables?: Object) => Promise<ApolloQueryResult<any>>;
+  startPolling: (pollInterval: number) => void;
+  stopPolling: () => void;
+  subscribeToMore: (options: SubscribeToMoreOptions) => () => void;
+  updateQuery: (
+    mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any,
+  ) => void;
+}
+
+export interface OptionProps<TProps, TResult, TVariables> {
+  ownProps: TProps;
+  data: GraphqlData<TResult, TVariables>;
+  mutate: MutationFunc<TResult, TVariables>;
+}
+
+export type OptionDescription<TProps, TVariables> =
+  | QueryOpts<TVariables>
+  | MutationOpts<TVariables>
+  | ((props: TProps) => QueryOpts<TVariables> | MutationOpts<TVariables>);
+
+export type NamedProps<P, R> = P & {
+  ownProps: R,
+};
+
+export interface OperationOption<
+  TResult: {},
+  TProps: {},
+  TChildProps: {},
+  TVariables: {},
+> {
+  +options?: OptionDescription<TProps, TVariables>;
+  props?: (
+    props: OptionProps<TProps, TResult, TVariables>,
+  ) => TChildProps | ChildProps<TProps, TResult, TVariables>;
+  +skip?: boolean | ((props: any) => boolean);
+  name?: string;
+  withRef?: boolean;
+  shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean;
+  alias?: string;
+}
+
+// Third argument of TMergedProps should be TVariables, but generics order
+// is preserved for backward compatibility.
+export interface OperationComponent<
+  TResult: Object = {},
+  TOwnProps: Object = {},
+  TMergedProps: Object = ChildProps<TOwnProps, TResult, {}>,
+  TVariables: Object = {},
+> {
+  (
+    component: React$ComponentType<TMergedProps>,
+  ): React$ComponentType<TOwnProps>;
+}
+
+declare export function graphql<TResult, TProps, TChildProps, TVariables>(
+  document: DocumentNode,
+  operationOptions?: OperationOption<TResult, TProps, TChildProps, TVariables>,
+): OperationComponent<TResult, TProps, TChildProps, TVariables>;
+
+declare type WithApolloOptions = {
+  withRef?: boolean,
+};
+
+declare export function withApollo<TProps>(
+  component: React$ComponentType<{ client: ApolloClient } & TProps>,
+  operationOptions?: WithApolloOptions,
+): React$ComponentType<TProps>;
+
+export interface IDocumentDefinition {
+  type: DocumentType;
+  name: string;
+  variables: VariableDefinitionNode[];
+}
+
+declare export function parser(document: DocumentNode): IDocumentDefinition;
+
+export interface Context {
+  client?: ApolloClient;
+  [key: string]: any;
+}
+
+export interface QueryTreeArgument {
+  rootElement: React$Element<*>;
+  rootContext?: Context;
+}
+
+export interface QueryResult {
+  query: Promise<ApolloQueryResult<mixed>>;
+  element: React$Element<*>;
+  context: Context;
+}
+
+declare export function walkTree(
+  element: React$Element<*>,
+  context: Context,
+  visitor: (
+    element: React$Element<*>,
+    instance: any,
+    context: Context,
+  ) => boolean | void,
+): void;
+
+declare export function getDataFromTree(
+  rootElement: React$Element<*>,
+  rootContext?: any,
+  fetchRoot?: boolean,
+): Promise<void>;
+
+declare export function renderToStringWithData(
+  component: React$Element<*>,
+): Promise<string>;
+
+declare export function cleanupApolloState(apolloState: any): void;


### PR DESCRIPTION
**Summary**

For reasons unknown to me this PR https://github.com/apollographql/react-apollo/pull/1801 removed Flow type defs from the repo, rendering Flow useless. 
This PR brings the file back.

**Test Plan**

Spawn a `flow-check` command on CI with Flow warnings enabled, so it errors when types are missing.