### PR TITLE
Optimise resubscription checks and allow shouldResubscribe to be a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "0.22.7",
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/enzyme-adapter-react-16": {
@@ -203,7 +203,7 @@
       "integrity": "sha512-kmNh8g67Ck/y/vp6KX+4JTJXiTGLZBylNhu+R7sm7zcvsrnIGVO6J1zew5inVg428j9f8yHpl68RcYOZXVborQ==",
       "dev": true,
       "requires": {
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/recompose": {
@@ -212,7 +212,7 @@
       "integrity": "sha512-5BfcDai1aOuZDe4z3IaVcCYRkMJMHZmPV1olzZJnLacIh96D1CqVU+dPVKoTP7OoLrNiQqCJDySAutoexDljfw==",
       "dev": true,
       "requires": {
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/zen-observable": {
@@ -2657,7 +2657,7 @@
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
         "react-reconciler": "0.7.0",
-        "react-test-renderer": "16.2.0"
+        "react-test-renderer": "16.3.0"
       }
     },
     "enzyme-adapter-utils": {
@@ -5188,7 +5188,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -5529,7 +5529,7 @@
       "requires": {
         "jest-mock": "22.2.0",
         "jest-util": "22.4.1",
-        "jsdom": "11.6.2"
+        "jsdom": "11.7.0"
       }
     },
     "jest-environment-node": {
@@ -5976,7 +5976,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -6257,7 +6257,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {

--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -19,7 +19,7 @@ export interface SubscriptionResult<TData = any> {
 export interface SubscriptionProps<TData = any, TVariables = OperationVariables> {
   subscription: DocumentNode;
   variables?: TVariables;
-  shouldResubscribe?: boolean;
+  shouldResubscribe?: any;
   children: (result: SubscriptionResult<TData>) => React.ReactNode;
 }
 
@@ -45,6 +45,7 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
     subscription: PropTypes.object.isRequired,
     variables: PropTypes.object,
     children: PropTypes.func.isRequired,
+    shouldResubscribe: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   };
 
   private client: ApolloClient<any>;
@@ -74,7 +75,12 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
     if (shallowEqual(this.props, nextProps) && this.client === nextContext.client) {
       return;
     }
-    const shouldNotResubscribe = this.props.shouldResubscribe === false;
+
+    let shouldResubscribe = nextProps.shouldResubscribe;
+    if (typeof shouldResubscribe === 'function') {
+      shouldResubscribe = !!shouldResubscribe(this.props.variables, nextProps.variables);
+    }
+    const shouldNotResubscribe = shouldResubscribe === false;
     if (this.client !== nextContext.client) {
       this.client = nextContext.client;
     }

--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -82,7 +82,7 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
 
     let shouldResubscribe = nextProps.shouldResubscribe;
     if (typeof shouldResubscribe === 'function') {
-      shouldResubscribe = !!shouldResubscribe(this.props.variables, nextProps.variables);
+      shouldResubscribe = !!shouldResubscribe(this.props, nextProps);
     }
     const shouldNotResubscribe = shouldResubscribe === false;
     if (this.client !== nextContext.client) {

--- a/src/Subscriptions.tsx
+++ b/src/Subscriptions.tsx
@@ -72,7 +72,11 @@ class Subscription<TData = any, TVariables = any> extends React.Component<
     nextProps: SubscriptionProps<TData, TVariables>,
     nextContext: SubscriptionContext,
   ) {
-    if (shallowEqual(this.props, nextProps) && this.client === nextContext.client) {
+    if (
+      shallowEqual(this.props.variables, nextProps.variables) &&
+      this.client === nextContext.client &&
+      this.props.subscription === nextProps.subscription
+    ) {
       return;
     }
 

--- a/test/client/Subscription.test.tsx
+++ b/test/client/Subscription.test.tsx
@@ -43,21 +43,6 @@ const client = new ApolloClient({
   cache,
 });
 
-const variablesLuke = { name: 'Luke Skywalker' };
-const variablesHan = { name: 'Han Solo' };
-
-const dataLuke = {
-  user: {
-    name: 'Luke Skywalker',
-  },
-};
-
-const dataHan = {
-  user: {
-    name: 'Han Solo',
-  },
-};
-
 it('executes the subscription', done => {
   jest.useFakeTimers();
 
@@ -162,6 +147,71 @@ it('executes subscription for the variables passed in the props', done => {
       }}
     </Subscription>
   );
+
+  wrapper = mount(
+    <ApolloProvider client={mockClient}>
+      <Component />
+    </ApolloProvider>,
+  );
+
+  mockLink.simulateResult(results[0]);
+});
+
+it('does not execute if variables have not changed', done => {
+  expect.assertions(4);
+  const subscriptionWithVariables = gql`
+    subscription UserInfo($name: String) {
+      user(name: $name) {
+        name
+      }
+    }
+  `;
+
+  const name = 'Luke Skywalker';
+
+  class MockSubscriptionLinkOverride extends MockSubscriptionLink {
+    request(req: Operation) {
+      catchAsyncError(done, () => {
+        expect(req.variables).toEqual({ name });
+      });
+      return super.request(req);
+    }
+  }
+
+  const mockLink = new MockSubscriptionLinkOverride();
+
+  const mockClient = new ApolloClient({
+    link: mockLink,
+    cache,
+  });
+
+  let count = 0;
+
+  class Component extends React.Component {
+    render() {
+      return (
+        <Subscription subscription={subscriptionWithVariables} variables={{ name }}>
+          {result => {
+            const { loading, data } = result;
+
+            catchAsyncError(done, () => {
+              if (count === 0) {
+                expect(loading).toBe(true);
+              } else if (count === 1) {
+                expect(loading).toBe(false);
+                setTimeout(() => this.forceUpdate());
+              } else if (count === 2) {
+                expect(loading).toBe(false);
+                done();
+              }
+            });
+            count++;
+            return null;
+          }}
+        </Subscription>
+      );
+    }
+  }
 
   wrapper = mount(
     <ApolloProvider client={mockClient}>
@@ -379,6 +429,45 @@ describe('should update', () => {
       }
     `;
 
+    const variablesLuke = { name: 'Luke Skywalker' };
+    const variablesHan = { name: 'Han Solo' };
+
+    const dataLuke = {
+      user: {
+        name: 'Luke Skywalker',
+      },
+    };
+
+    const dataHan = {
+      user: {
+        name: 'Han Solo',
+      },
+    };
+
+    class MockSubscriptionLinkOverride extends MockSubscriptionLink {
+      variables: any;
+      request(req: Operation) {
+        this.variables = req.variables;
+        return super.request(req);
+      }
+
+      simulateResult() {
+        if (this.variables.name === 'Luke Skywalker') {
+          return super.simulateResult({
+            result: {
+              data: dataLuke,
+            },
+          });
+        } else if (this.variables.name === 'Han Solo') {
+          return super.simulateResult({
+            result: {
+              data: dataHan,
+            },
+          });
+        }
+      }
+    }
+
     const mockLink = new MockSubscriptionLinkOverride();
 
     const mockClient = new ApolloClient({
@@ -444,6 +533,45 @@ describe('should update', () => {
 });
 
 describe('should not update', () => {
+  const variablesLuke = { name: 'Luke Skywalker' };
+  const variablesHan = { name: 'Han Solo' };
+
+  const dataLuke = {
+    user: {
+      name: 'Luke Skywalker',
+    },
+  };
+
+  const dataHan = {
+    user: {
+      name: 'Han Solo',
+    },
+  };
+
+  class MockSubscriptionLinkOverride extends MockSubscriptionLink {
+    variables: any;
+    request(req: Operation) {
+      this.variables = req.variables;
+      return super.request(req);
+    }
+
+    simulateResult() {
+      if (this.variables.name === 'Luke Skywalker') {
+        return super.simulateResult({
+          result: {
+            data: dataLuke,
+          },
+        });
+      } else if (this.variables.name === 'Han Solo') {
+        return super.simulateResult({
+          result: {
+            data: dataHan,
+          },
+        });
+      }
+    }
+  }
+
   it('if shouldResubscribe is false', done => {
     const subscriptionWithVariables = gql`
       subscription UserInfo($name: String) {
@@ -590,29 +718,3 @@ describe('should not update', () => {
     mockLink.simulateResult();
   });
 });
-
-class MockSubscriptionLinkOverride extends MockSubscriptionLink {
-  variables: any;
-  request(req: Operation) {
-    this.variables = req.variables;
-    return super.request(req);
-  }
-
-  simulateResult() {
-    if (this.variables.name === 'Luke Skywalker') {
-      return super.simulateResult({
-        result: {
-          data: dataLuke,
-        },
-      });
-    } else if (this.variables.name === 'Han Solo') {
-      return super.simulateResult({
-        result: {
-          data: dataHan,
-        },
-      });
-    } else {
-      done.fail(`Unknown variable ${String(this.variables)}`);
-    }
-  }
-}


### PR DESCRIPTION
### Checklist:

* [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

I started investigating this when i noticed that my subscribed components were frequently missing messages that were definitely sent to the browser. On looking at the websocket frames, I noticed loads of resubscriptions occurring when no variables had actually changed:

![screen shot 2018-04-05 at 12 06 19](https://user-images.githubusercontent.com/621323/38366000-48ae3a26-38d6-11e8-95ea-8da4894fd1d1.png)

If you look closely, you can see `stop` requests being sent immediately after data frames have been received. All these stops match up to UI re-renders. My theory is that upon every re-render, the subscription gets torn down and recreated. During this recreation, if a message arrives, it gets ignored because nothing is currently subscribed to it.

To verify i tried setting `shouldResubscribe` to false. This worked; I no longer missed any messages, and the crazy amount of resubscriptions disappeared (obviously):

![screen shot 2018-04-05 at 12 04 48](https://user-images.githubusercontent.com/621323/38366169-d7e1eba2-38d6-11e8-9019-97f0a9081fdf.png)

As far as I can tell, when the old subscription HOC was ported to the new `Subscription` component, the logic of checking whether we could bail from resubscription based on prop equality was [simply copy-pasted across](https://github.com/apollographql/react-apollo/blob/d58d9b85865eb799a9407bd523331e86d493a7f5/src/graphql.tsx#L174). This `shallowEqual` comparison check makes sense in a HOC where the props you are receiving are actually the ones destined for the inner component.

However in the new `Subscription` component this shallow equality check makes no sense anymore. If you pass the variables prop as a new object on each render, the equality check will fail every time. Forcing the user to pass the same object instance on subsequent renders is cumbersome. This PR attempts to fix this by doing the shallow equality check directly on the props, and then additionally checking the subscription query for equality as well.

Something else I noticed while fixing this was that in the old HOC world, `shouldResubscribe` was a function that was given the current props and the next props. In the new world, the `Subscription` component only accepts `shouldResubscribe` as a boolean which kinda makes it useless to consumers unless you want to permanently block resubscription. I've added back support for it to be a function.
