### PR TITLE
SSR enable asynchronous refetch call

### DIFF
--- a/test/client/graphql/queries/__snapshots__/lifecycle.test.tsx.snap
+++ b/test/client/graphql/queries/__snapshots__/lifecycle.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[queries] lifecycle handles asynchronous racecondition with prefilled data from the server 1`] = `
+<p>
+   stub 
+</p>
+`;


### PR DESCRIPTION
Adds a failing test and provides the fix for when refetch is called asynchronously from render. The component mounts, which starts the observable query subscription. Normally this would fetch data, causing a render, and the instance of refetch would be overridden with the force network. In cases of SSR, this second render does not occur. The refetch passed in the original render call needs to take this into account.

### Checklist:

* [x] Make sure all of the significant new logic is covered by tests

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->