### PR TITLE
Bumped version of hoist-non-react-statics to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "dev": true,
       "requires": {
         "@types/cheerio": "0.22.7",
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/enzyme-adapter-react-16": {
@@ -203,7 +203,7 @@
       "integrity": "sha512-kmNh8g67Ck/y/vp6KX+4JTJXiTGLZBylNhu+R7sm7zcvsrnIGVO6J1zew5inVg428j9f8yHpl68RcYOZXVborQ==",
       "dev": true,
       "requires": {
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/recompose": {
@@ -212,7 +212,7 @@
       "integrity": "sha512-5BfcDai1aOuZDe4z3IaVcCYRkMJMHZmPV1olzZJnLacIh96D1CqVU+dPVKoTP7OoLrNiQqCJDySAutoexDljfw==",
       "dev": true,
       "requires": {
-        "@types/react": "16.0.35"
+        "@types/react": "16.1.0"
       }
     },
     "@types/zen-observable": {
@@ -2657,7 +2657,7 @@
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
         "react-reconciler": "0.7.0",
-        "react-test-renderer": "16.2.0"
+        "react-test-renderer": "16.3.0"
       }
     },
     "enzyme-adapter-utils": {
@@ -5188,7 +5188,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -5529,7 +5529,7 @@
       "requires": {
         "jest-mock": "22.2.0",
         "jest-util": "22.4.1",
-        "jsdom": "11.6.2"
+        "jsdom": "11.7.0"
       }
     },
     "jest-environment-node": {
@@ -5976,7 +5976,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {
@@ -6257,7 +6257,7 @@
           "requires": {
             "jest-mock": "22.4.3",
             "jest-util": "22.4.3",
-            "jsdom": "11.6.2"
+            "jsdom": "11.7.0"
           }
         },
         "jest-environment-node": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "dependencies": {
     "fbjs": "^0.8.16",
-    "hoist-non-react-statics": "^2.3.1",
+    "hoist-non-react-statics": "^2.5.0",
     "invariant": "^2.2.2",
     "lodash": "4.17.5",
     "prop-types": "^15.6.0"


### PR DESCRIPTION
Bumped version of hoist-non-react-statics to 2.5.0 for compatibility with react 16.3.0

Fixes issue #1899

