### PR TITLE
Include ApolloClient in MutationResult

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -14,6 +14,7 @@ export interface MutationResult<TData = Record<string, any>> {
   error?: ApolloError;
   loading: boolean;
   called: boolean;
+  client: ApolloClient<Object>;
 }
 export interface MutationContext {
   client: ApolloClient<Object>;
@@ -157,6 +158,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
       loading,
       data,
       error,
+      client: this.client,
     };
 
     return children(this.runMutation, result);


### PR DESCRIPTION
ApolloClient is already exposed in the `Query` component; this adds it to `Mutation` as well. For example, after this PR you can call `client.resetStore()` after logging in. 

Tested and verified locally.

/label feature