### PR TITLE
Change ApolloProvider children protype from element to node

### DIFF
--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -14,7 +14,7 @@ export interface ApolloProviderProps<TCache> {
 export default class ApolloProvider<TCache> extends Component<ApolloProviderProps<TCache>> {
   static propTypes = {
     client: PropTypes.object.isRequired,
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node.isRequired,
   };
 
   static childContextTypes = {

--- a/test/client/ApolloProvider.test.tsx
+++ b/test/client/ApolloProvider.test.tsx
@@ -149,15 +149,17 @@ describe('<ApolloProvider /> Component', () => {
   //   console.error = originalConsoleError;
   // });
 
-  it('should add the client to the child context', () => {
+  it('should add the client to the children context', () => {
     const tree = TestUtils.renderIntoDocument(
       <ApolloProvider client={client}>
+        <Child />
         <Child />
       </ApolloProvider>,
     ) as React.Component<any, any>;
 
-    const child = TestUtils.findRenderedComponentWithType(tree, Child);
-    expect(child.context.client).toEqual(client);
+    TestUtils.scryRenderedComponentsWithType(tree, Child).forEach(child => {
+      expect(child.context.client).toEqual(client);
+    });
   });
 
   it('should update props when the client changes', () => {


### PR DESCRIPTION
Since https://github.com/apollographql/react-apollo/pull/1715 `ApolloProvider` does not require a single child element anymore. Fix https://github.com/apollographql/react-apollo/issues/1940

### Checklist:

* [x] Make sure all of the significant new logic is covered by tests