### PR TITLE
Created a reproduction of the issue with the skip property.

### DIFF
--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -688,6 +688,27 @@ describe('Query component', () => {
         done();
       });
     });
+
+    it('skip property', done => {
+      const Component = () => (
+        <Query query={allPeopleQuery}>
+          {result => {
+            catchAsyncError(done, () => {
+              expect(result.loading).toBe(false);
+              done();
+            });
+
+            return null;
+          }}
+        </Query>
+      );
+
+      wrapper = mount(
+        <MockedProvider mocks={allPeopleMocks}>
+          <Component />
+        </MockedProvider>,
+      );
+    });
   });
 
   describe('props disallow', () => {


### PR DESCRIPTION
Created a reproduction of an issue where setting the prop `skip` to true in the `Query` component caused the `loading` value to always be true. I have a feeling that this is an issue in `apollo-client` given that the `loading` value is retrieved by calling the `currentResult()` method which is part of `apollo-client`.

Reproduction of issues: #1931, #1869 