### PR TITLE
Update renovate.json to only pin `devDependencies`.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "pinVersions": true,
+  "extends": [":pinOnlyDevDependencies"],
   "semanticCommits": true,
   "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
I'm raising this PR after noticing https://github.com/apollographql/react-apollo/pull/1921, which exhibited confusing pinning similar to that which I originally discovered in (`apollo-server`'s) https://github.com/apollographql/apollo-server/pull/954.

This changes Renovate to only pin the `devDependencies` in a `package.json` rather than all dependencies.

This is in the same spirit as the net result of (https://github.com/apollographql/apollo-server/commit/441cd9b838658132058945808097b97096bcb39f + https://github.com/apollographql/apollo-server/commit/db174a9b02354303ff845606e4c7bbfa03e58286) which were merged into `apollo-server`, as discussed in https://github.com/apollographql/apollo-server/pull/955#discussion_r180413510.