### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ To learn more about querying with React Apollo be sure to start reading the [doc
 [`apolloclient`]: https://www.apollographql.com/docs/react/api/apollo-client.html
 [`<apolloprovider/>`]: https://www.apollographql.com/docs/react/essentials/get-started.html#creating-provider
 [`graphql()`]: http://dev.apollodata.com/react/api.html#graphql
-[`createnetworkinterface`]: http://dev.apollodata.com/core/network.html
 [`<provider/>` component in `react-redux`]: https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store
 [documentation article on queries]: http://dev.apollodata.com/react/queries.html
 [documentation]: https://www.apollographql.com/docs/react/

--- a/README.md
+++ b/README.md
@@ -111,18 +111,16 @@ export default graphql(gql`
 
 With that your `<TodoApp/>` component is now connected to your GraphQL API. Whenever some other component modifies the data in your cache, this component will automatically be updated with the new data.
 
-To learn more about querying with React Apollo be sure to start reading the [documentation article on Queries][]. If you would like to see all of the features React Apollo supports be sure to check out the [complete API reference][].
+To learn more about querying with React Apollo be sure to start reading the [documentation article on Queries][]. If you would like to see all of the features React Apollo supports be sure to check out the [documentation][].
 
 
-[`apolloclient`]: http://dev.apollodata.com/core/apollo-client-api.html#apollo-client
-[`<apolloprovider/>`]: http://dev.apollodata.com/react/api.html#ApolloProvider
+[`apolloclient`]: https://www.apollographql.com/docs/react/api/apollo-client.html
+[`<apolloprovider/>`]: https://www.apollographql.com/docs/react/essentials/get-started.html#creating-provider
 [`graphql()`]: http://dev.apollodata.com/react/api.html#graphql
 [`createnetworkinterface`]: http://dev.apollodata.com/core/network.html
 [`<provider/>` component in `react-redux`]: https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store
 [documentation article on queries]: http://dev.apollodata.com/react/queries.html
-[complete api reference]: http://dev.apollodata.com/react/api.html
-[**full-stack react + graphql tutorial**]: https://dev-blog.apollodata.com/full-stack-react-graphql-tutorial-582ac8d24e3b#.w8e9j7jmp
-[learn apollo]: https://www.learnapollo.com/
+[documentation]: https://www.apollographql.com/docs/react/
 
 ## Documentation
 


### PR DESCRIPTION
Similar to #2102, this PR fixes broken links the README.

- ApolloProvider link
- API reference link
- Apollo Client link
- removed 3 deprecated links


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->