### PR TITLE
Move deprecation to correct section

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -104,6 +104,7 @@
 - **BREAKING CHANGES [Removal of deprecated code]**
 
   - Remove deprecated `operationOptions.options.skip`, use `operationOptions.skip` instead
+  - Remove deprecated [`options.updateQueries`](https://www.apollographql.com/docs/react/basics/mutations.html#graphql-mutation-options-updateQueries), use [`options.update`](https://www.apollographql.com/docs/react/basics/mutations.html#graphql-mutation-options-update) instead [#1485](https://github.com/apollographql/react-apollo/pull/1485)
 
 - **BREAKING CHANGES [TypeScript and Flow only]**
 
@@ -114,7 +115,6 @@
   - Rename type `ProviderProps` to `ApolloProviderProps` [#1467](https://github.com/apollographql/react-apollo/pull/1467)
   - Rename `getDataFromTree` type `QueryResult` to `QueryTreeResult` [#1467](https://github.com/apollographql/react-apollo/pull/1467)
   - Rename type `QueryProps` to `GraphqlQueryControls` [#1467](https://github.com/apollographql/react-apollo/pull/1467) [#1478](https://github.com/apollographql/react-apollo/pull/1478)
-  - Remove deprecated [`options.updateQueries`](https://www.apollographql.com/docs/react/basics/mutations.html#graphql-mutation-options-updateQueries), use [`options.update`](https://www.apollographql.com/docs/react/basics/mutations.html#graphql-mutation-options-update) instead [#1485](https://github.com/apollographql/react-apollo/pull/1485)
 
 - **Fixes and Improvements**
   - Fixed bug where link error prevents future requests


### PR DESCRIPTION
This change is under the TypeScript and Flow only section, but is a change to the public API. People that aren't using flow or typescript might skip over this section and miss this important deprecation.
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->