### PR TITLE
Added custom cache option to MockedProvider

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 2.1.8 (June 28, 2018)
+
+- Allow a custom `Cache` to be passed into `MockedProvider` via props.  
+  [@2142](https://github.com/JakeDawkins) in [#2142](https://github.com/apollographql/react-apollo/pull/2142)
+
 ## 2.1.7 (June 27, 2018)
 
 - The `ApolloProvider` `children` prop type has been changed from `element`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -18,7 +18,7 @@ export class MockedProvider extends React.Component<any, any> {
     const link = new MockLink(this.props.mocks, this.props.addTypename);
     this.client = new ApolloClient({
       link,
-      cache: new Cache({ addTypename: this.props.addTypename }),
+      cache: this.props.cache || new Cache({ addTypename: this.props.addTypename }),
       defaultOptions: this.props.defaultOptions,
     });
   }

--- a/test/test-utils.test.tsx
+++ b/test/test-utils.test.tsx
@@ -235,7 +235,6 @@ it('allows a custom cache to be used for the MockedProvider', done => {
   class Container extends React.Component<ChildProps<Variables, Data, Variables>> {
     componentWillReceiveProps(nextProps: ChildProps<Variables, Data, Variables>) {
       expect(nextProps.data!.user!.id).toEqual('custom');
-      console.log(nextProps.data);
       done();
     }
 

--- a/test/test-utils.test.tsx
+++ b/test/test-utils.test.tsx
@@ -227,3 +227,33 @@ it('errors if the query in the mock and component do not match', done => {
     </MockedProvider>,
   );
 });
+
+it('allows a custom cache to be used for the MockedProvider', done => {
+  const customCache = new InMemoryCache();
+  customCache.writeQuery({ query, variables, data: { user: { ...user, id: 'custom' } } });
+
+  class Container extends React.Component<ChildProps<Variables, Data, Variables>> {
+    componentWillReceiveProps(nextProps: ChildProps<Variables, Data, Variables>) {
+      expect(nextProps.data!.user!.id).toEqual('custom');
+      console.log(nextProps.data);
+      done();
+    }
+
+    render() {
+      return null;
+    }
+  }
+
+  const ContainerWithData = graphql<Variables, Data, Variables>(query, {
+    options: props => ({
+      variables: props,
+      fetchPolicy: 'cache-only',
+    }),
+  })(Container);
+
+  renderer.create(
+    <MockedProvider mocks={mocks} cache={customCache} addTypename={false}>
+      <ContainerWithData {...variables} />
+    </MockedProvider>,
+  );
+});


### PR DESCRIPTION
Someone using MockedProvider in a project with fragments ran into an issue where they couldn't test a component, because of the default `HeuristicFragmentMatcher`. Since there was no way to control what cache was used with the original `MockedProvider`, I added a prop to it that allows a custom `Cache` to be passed in.

This also will allow people to preload caches, etc when testing components

I added an example in the tests

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->