### PR TITLE
Clear out scheduler on MockedProvider unmount

### DIFF
--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -38,4 +38,14 @@ export class MockedProvider extends React.Component<MockedProviderProps, MockedP
   public render() {
     return <ApolloProvider client={this.state.client}>{this.props.children}</ApolloProvider>;
   }
+
+  public componentWillUnmount() {
+    const scheduler = this.state.client.queryManager.scheduler;
+    Object.keys(scheduler.registeredQueries).forEach(queryId => {
+      scheduler.stopPollingQuery(queryId);
+    });
+    Object.keys(scheduler.intervalQueries).forEach((interval: any) => {
+      scheduler.fetchQueriesOnInterval(interval);
+    });
+  }
 }

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,29 +1,41 @@
 import * as React from 'react';
 import ApolloClient from 'apollo-client';
+import { DefaultOptions } from 'apollo-client/ApolloClient';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 
 import { ApolloProvider } from './index';
-import { MockLink } from './test-links';
+import { MockedResponse, MockLink } from './test-links';
 export * from './test-links';
 
-export class MockedProvider extends React.Component<any, any> {
-  static defaultProps = {
+export interface MockedProviderProps {
+  mocks?: MockedResponse[];
+  addTypename?: boolean;
+  defaultOptions?: DefaultOptions;
+}
+
+export interface MockedProviderState {
+  client: ApolloClient<any>;
+}
+
+export class MockedProvider extends React.Component<MockedProviderProps, MockedProviderState> {
+  public static defaultProps: MockedProviderProps = {
     addTypename: true,
   };
 
-  private client: any;
+  constructor(props: MockedProviderProps) {
+    super(props);
 
-  constructor(props: any, context: any) {
-    super(props, context);
-    const link = new MockLink(this.props.mocks, this.props.addTypename);
-    this.client = new ApolloClient({
-      link,
-      cache: new Cache({ addTypename: this.props.addTypename }),
-      defaultOptions: this.props.defaultOptions,
+    const { mocks, addTypename, defaultOptions } = this.props;
+    const client = new ApolloClient({
+      cache: new Cache({ addTypename }),
+      defaultOptions,
+      link: new MockLink(mocks || [], addTypename),
     });
+
+    this.state = { client };
   }
 
-  render() {
-    return <ApolloProvider client={this.client}>{this.props.children}</ApolloProvider>;
+  public render() {
+    return <ApolloProvider client={this.state.client}>{this.props.children}</ApolloProvider>;
   }
 }


### PR DESCRIPTION
Currently using `pollInterval` leads to the following jest error message while testing:
```
Jest did not exit one second after the test run has completed.
This usually means that there are asynchronous operations that weren't stopped in your tests.
```

This is because when `stopPolling` is called, the actual polling timer is not getting deleted right away but after the interval completes. So we have to wait for one whole interval before jest can exist. See `fetchQueriesOnInterval` in the scheduler for the implementation details. 

This PR assumes that `MockedProvider` is only ever run with the intention that when it is unmounted every client op should also stop.

When `MockedProvider` is going to be unmounted, this PR adds the functionality to loop over all existing registered queries in the scheduler and clearing their intervals immediately.