### PR TITLE
Support UNSAFE_componentWillMount in SSR

### DIFF
--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -99,6 +99,8 @@ export function walkTree(
           if (result !== null) {
             instance.state = Object.assign({}, instance.state, result);
           }
+        } else if (instance.UNSAFE_componentWillMount) {
+          instance.UNSAFE_componentWillMount();
         } else if (instance.componentWillMount) {
           instance.componentWillMount();
         }

--- a/test/client/getDataFromTree.test.tsx
+++ b/test/client/getDataFromTree.test.tsx
@@ -361,6 +361,31 @@ describe('SSR', () => {
         expect(renderedCounts).toEqual([1]);
       });
 
+      it('basic classes with UNSAFE_componentWillMount', () => {
+        class MyComponent extends React.Component<any> {
+          state = { count: 0 };
+
+          UNSAFE_componentWillMount() {
+            this.setState({ count: 1 });
+          }
+
+          componentWillMount() {
+            throw new Error(
+              "`componentWillMount` shouldn't be called when " +
+                '`UNSAFE_componentWillMount` is available',
+            );
+          }
+
+          render() {
+            expect(this.state.count).toBe(1);
+            return <div>{this.state.count}</div>;
+          }
+        }
+        walkTree(<MyComponent />, {}, () => {
+          // noop
+        });
+      });
+
       it('basic classes with React 16.3 context', () => {
         if (!React.createContext) {
           // Preact doesn't support createContext yet, see https://github.com/developit/preact/pull/963


### PR DESCRIPTION
Since the existing `walkTree` implementation already calls `componentWillMount` if the method is defined, this is just a matter of adding a similar check & call for the UNSAFE_ variant.

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
