### PR TITLE
Call onCompleted with data from cache

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -197,6 +197,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
   componentDidMount() {
     this.hasMounted = true;
     if (this.props.skip) return;
+    this.updateCurrentData();
     this.startQuerySubscription();
     if (this.refetcherQueue) {
       const { args, resolve, reject } = this.refetcherQueue;


### PR DESCRIPTION
This is a first attempt to fix #2177. If there's data at the time the component mounts, `onCompleted` will be called.

I'm not sure if this is the right direction, but I didn't have much time to look at the codebase and try to understand it. If anyone could take a look and let me know what they think I'd really appreciate it. If the changes are good, I'll put some effort into fixing the tests and writing new ones.

Thanks!