### PR TITLE
[WIP] Add @defer support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Added `@defer` support [#2192](https://github.com/apollographql/react-apollo/pull/2192)
 - Fixed an issue in `getDataFromTree` where queries that threw more than one
   error had error messages swallowed, and returned an invalid error object
   with circular references. Multiple errors are now preserved. <br/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.3",
   "author": "opensource@apollographql.com",
   "browser": "lib/react-apollo.browser.umd.js",
   "description": "React data container for Apollo Client",
@@ -87,7 +87,7 @@
     "trailingComma": "all"
   },
   "peerDependencies": {
-    "apollo-client": "2.4.0-alpha.13",
+    "apollo-client": "alpha",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.1.9",
+  "version": "2.2.0-alpha.1",
   "author": "opensource@apollographql.com",
   "browser": "lib/react-apollo.browser.umd.js",
   "description": "React data container for Apollo Client",
@@ -87,7 +87,7 @@
     "trailingComma": "all"
   },
   "peerDependencies": {
-    "apollo-client": "^2.3.7",
+    "apollo-client": "2.4.0-alpha.13",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
@@ -104,9 +104,9 @@
     "@types/react-test-renderer": "16.0.1",
     "@types/recompose": "0.26.3",
     "@types/zen-observable": "0.8.0",
-    "apollo-cache": "1.1.13",
-    "apollo-cache-inmemory": "1.2.6",
-    "apollo-client": "2.3.7",
+    "apollo-cache": "1.1.13-alpha.13",
+    "apollo-cache-inmemory": "1.2.6-alpha.13",
+    "apollo-client": "2.4.0-alpha.13",
     "apollo-link": "1.2.1",
     "babel-core": "6.26.3",
     "babel-jest": "23.4.2",

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -98,6 +98,7 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
+  loadingState?: Record<string, any>;
 }
 
 export interface QueryProps<TData = any, TVariables = OperationVariables> {
@@ -379,14 +380,14 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     Object.assign(data, observableQueryFields(this.queryObservable!));
     // fetch the current result (if any) from the store
     const currentResult = this.queryObservable!.currentResult();
-    const { loading, networkStatus, errors } = currentResult;
+    const { loading, networkStatus, errors, loadingState } = currentResult;
     let { error } = currentResult;
     // until a set naming convention for networkError and graphQLErrors is decided upon, we map errors (graphQLErrors) to the error props
     if (errors && errors.length > 0) {
       error = new ApolloError({ graphQLErrors: errors });
     }
 
-    Object.assign(data, { loading, networkStatus, error });
+    Object.assign(data, { loading, networkStatus, error, loadingState });
 
     if (loading) {
       Object.assign(data.data, this.previousData, currentResult.data);

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -339,7 +339,11 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
 
   private removeQuerySubscription = () => {
     if (this.querySubscription) {
-      this.querySubscription.unsubscribe();
+      const currentResult = this.queryObservable!.currentResult();
+      const { networkStatus } = currentResult;
+      if (networkStatus === NetworkStatus.ready) {
+        this.querySubscription.unsubscribe();
+      } // Otherwise do not tear down observable that is still receiving patches
       delete this.querySubscription;
     }
   };
@@ -362,8 +366,8 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     const { onCompleted, onError } = this.props;
     if (onCompleted || onError) {
       const currentResult = this.queryObservable!.currentResult();
-      const { loading, error, data } = currentResult;
-      if (onCompleted && !loading && !error) {
+      const { loading, error, data, networkStatus } = currentResult;
+      if (onCompleted && !loading && !error && networkStatus === NetworkStatus.ready) {
         onCompleted(data);
       } else if (onError && !loading && error) {
         onError(error);

--- a/test/client/__snapshots__/Query.test.tsx.snap
+++ b/test/client/__snapshots__/Query.test.tsx.snap
@@ -23,6 +23,7 @@ Object {
   "error": undefined,
   "fetchMore": [Function],
   "loading": true,
+  "loadingState": undefined,
   "networkStatus": 1,
   "refetch": [Function],
   "startPolling": [Function],


### PR DESCRIPTION
Changes:
- [x] Expose `loadingState` on the `Query` component for deferred queries.
- [x] When a deferred query component is unmounted, do not tear down the subscription so deferred fields can continue to stream in.