### PR TITLE
Revert "Use Partial<TData> rather than TData | {} (#2313)"

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -66,7 +66,15 @@ function observableQueryFields<TData, TVariables>(
 export interface QueryResult<TData = any, TVariables = OperationVariables>
   extends ObservableQueryFields<TData, TVariables> {
   client: ApolloClient<any>;
-  data: Partial<TData>;
+  // we create an empty object to make checking for data
+  // easier for consumers (i.e. instead of data && data.user
+  // you can just check data.user) this also makes destructring
+  // easier (i.e. { data: { user } })
+  // however, this isn't realy possible with TypeScript that
+  // I'm aware of. So intead we enforce checking for data
+  // like so result.data!.user. This tells TS to use TData
+  // XXX is there a better way to do this?
+  data: TData | {};
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;

--- a/src/query-hoc.tsx
+++ b/src/query-hoc.tsx
@@ -87,7 +87,7 @@ export function query<
               // we massage the Query components shape here to replicate that
               const result = Object.assign(r, data || {});
               const name = operationOptions.name || 'data';
-              let childProps: TChildProps = { [name]: result } as any;
+              let childProps = { [name]: result };
               if (operationOptions.props) {
                 const newResult: OptionProps<TProps, TData, TGraphQLVariables> = {
                   [name]: result,

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -1331,7 +1331,7 @@ describe('Query component', () => {
     function Container() {
       return (
         <AllPeopleQuery2 query={query} notifyOnNetworkStatusChange>
-          {result => {
+          {(result: any) => {
             try {
               switch (count++) {
                 case 0:

--- a/test/client/getDataFromTree.test.tsx
+++ b/test/client/getDataFromTree.test.tsx
@@ -542,7 +542,7 @@ describe('SSR', () => {
 
       const WrappedElement = () => (
         <CurrentUserQuery query={query}>
-          {({ data, loading }) => (
+          {({ data, loading }: { data: Data; loading: boolean }) => (
             <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
           )}
         </CurrentUserQuery>
@@ -1291,7 +1291,7 @@ describe('SSR', () => {
 
       const Element = (props: { id: string }) => (
         <CurrentUserQuery query={query} ssr={false} variables={props}>
-          {({ data, loading }) => (
+          {({ data, loading }: { data: Data; loading: boolean }) => (
             <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
           )}
         </CurrentUserQuery>


### PR DESCRIPTION
This reverts commit 2f15d9ff27574540ac4d873cc42a1ae64a6e663c.

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.


#2313 introduced use of [Partial](http://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types) for `TData` on a query result which makes all properties optional and is not correct or equal to the previous `TData | {}`.

@hwillson we should get a patch out asap as this is a **breaking change** in `2.2.0` for all users who are strongly typed.

/cc @tgriesser @donataswix 