### PR TITLE
Revert 27cc028 (https://github.com/apollographql/react-apollo/pull/1983)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,7 +39,7 @@
 - The `graphql` `options` object is no longer mutated, when calculating
   variables from props. This now prevents an issue where components created
   with `graphql` were not having their query variables updated properly, when
-  props changed.
+  props changed. <br/>
   [@ksmth](https://github.com/ksmth) in [#1968](https://github.com/apollographql/react-apollo/pull/1968)
 - When a query failed on the first result, the query result `data` was being
   returned as `undefined`. This behavior has been changed so that `data` is
@@ -112,13 +112,13 @@
   in `refetchQueries` will be completed before the mutation itself is
   completed. `awaitRefetchQueries` is `false` by default, which means
   `refetchQueries` are usually completed after the mutation has resolved.
-  Relates to Apollo Client
+  Relates to Apollo Client <br/>
   [PR #3169](https://github.com/apollographql/apollo-client/pull/3169). <br/>
   [@hwillson](https://github.com/hwillson) in [#2214](https://github.com/apollographql/react-apollo/pull/2214)
 - Typings adjustment: pass `TData` along into `MutationUpdaterFn` when using
   `MutationOpts`, to ensure that the updater function is properly typed. <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#2227](https://github.com/apollographql/react-apollo/pull/2227)
-- Check if queryManager is set before accessing it.
+- Check if queryManager is set before accessing it. <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#2165](https://github.com/apollographql/react-apollo/pull/2165)
 
 ## 2.1.9 (July 4, 2018)

--- a/Changelog.md
+++ b/Changelog.md
@@ -112,7 +112,7 @@
   in `refetchQueries` will be completed before the mutation itself is
   completed. `awaitRefetchQueries` is `false` by default, which means
   `refetchQueries` are usually completed after the mutation has resolved.
-  Relates to Apollo Client <br/>
+  Relates to Apollo Client. <br/>
   [PR #3169](https://github.com/apollographql/apollo-client/pull/3169). <br/>
   [@hwillson](https://github.com/hwillson) in [#2214](https://github.com/apollographql/react-apollo/pull/2214)
 - Typings adjustment: pass `TData` along into `MutationUpdaterFn` when using

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,16 @@
   provider value is reset to the previous value it had after its children are
   walked. <br/>
   [@mitchellhamilton](https://github.com/mitchellhamilton) in [#2304](https://github.com/apollographql/react-apollo/pull/2304)
+- Revert: <br/>
+  When a query failed on the first result, the query result `data` was being
+  returned as `undefined`. This behavior has been changed so that `data` is
+  returned as an empty object. This makes checking for data (e.g.
+  instead of `data && data.user` you can just check `data.user`) and
+  destructring (e.g. `{ data: { user } }`) easier. **Note:** this could
+  potentially hurt applications that are relying on a falsey check of `data`
+  to see if any query errors have occurred. A better (and supported) way to
+  check for errors is to use the result `errors` property. <br/>
+  [#1983](https://github.com/apollographql/react-apollo/pull/1983)
 
 ## 2.2.1 (September 26, 2018)
 
@@ -29,7 +39,7 @@
 - The `graphql` `options` object is no longer mutated, when calculating
   variables from props. This now prevents an issue where components created
   with `graphql` were not having their query variables updated properly, when
-  props changed. <br/>
+  props changed.
   [@ksmth](https://github.com/ksmth) in [#1968](https://github.com/apollographql/react-apollo/pull/1968)
 - When a query failed on the first result, the query result `data` was being
   returned as `undefined`. This behavior has been changed so that `data` is
@@ -102,13 +112,13 @@
   in `refetchQueries` will be completed before the mutation itself is
   completed. `awaitRefetchQueries` is `false` by default, which means
   `refetchQueries` are usually completed after the mutation has resolved.
-  Relates to Apollo Client. <br/>
+  Relates to Apollo Client
   [PR #3169](https://github.com/apollographql/apollo-client/pull/3169). <br/>
   [@hwillson](https://github.com/hwillson) in [#2214](https://github.com/apollographql/react-apollo/pull/2214)
 - Typings adjustment: pass `TData` along into `MutationUpdaterFn` when using
   `MutationOpts`, to ensure that the updater function is properly typed. <br/>
   [@danilobuerger](https://github.com/danilobuerger) in [#2227](https://github.com/apollographql/react-apollo/pull/2227)
-- Check if queryManager is set before accessing it. <br/>
+- Check if queryManager is set before accessing it.
   [@danilobuerger](https://github.com/danilobuerger) in [#2165](https://github.com/apollographql/react-apollo/pull/2165)
 
 ## 2.1.9 (July 4, 2018)

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -74,7 +74,7 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   // I'm aware of. So intead we enforce checking for data
   // like so result.data!.user. This tells TS to use TData
   // XXX is there a better way to do this?
-  data: TData | {};
+  data: TData | undefined;
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
@@ -391,12 +391,9 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       if (loading) {
         Object.assign(data.data, this.previousData, currentResult.data);
       } else if (error) {
-        const lastResult = this.queryObservable!.getLastResult();
-        if (lastResult) {
-          Object.assign(data, {
-            data: lastResult.data,
-          });
-        }
+        Object.assign(data, {
+          data: (this.queryObservable!.getLastResult() || {}).data,
+        });
       } else {
         const { fetchPolicy } = this.queryObservable!.options;
         const { partialRefetch } = this.props;

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -163,7 +163,6 @@ describe('Query component', () => {
               return null;
             }
             catchAsyncError(done, () => {
-              expect(result.data).toEqual({});
               expect(result.error).toEqual(new Error('Network error: error occurred'));
               done();
             });
@@ -1331,7 +1330,7 @@ describe('Query component', () => {
     function Container() {
       return (
         <AllPeopleQuery2 query={query} notifyOnNetworkStatusChange>
-          {(result: any) => {
+          {result => {
             try {
               switch (count++) {
                 case 0:

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -1330,7 +1330,7 @@ describe('Query component', () => {
     function Container() {
       return (
         <AllPeopleQuery2 query={query} notifyOnNetworkStatusChange>
-          {result => {
+          {(result: any) => {
             try {
               switch (count++) {
                 case 0:

--- a/test/client/getDataFromTree.test.tsx
+++ b/test/client/getDataFromTree.test.tsx
@@ -531,7 +531,7 @@ describe('SSR', () => {
       });
 
       interface Data {
-        currentUser: {
+        currentUser?: {
           firstName: string;
         };
       }
@@ -541,7 +541,7 @@ describe('SSR', () => {
       const WrappedElement = () => (
         <CurrentUserQuery query={query}>
           {({ data, loading }) => (
-            <div>{loading || !data ? 'loading' : data.currentUser.firstName}</div>
+            <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
           )}
         </CurrentUserQuery>
       );
@@ -1280,7 +1280,7 @@ describe('SSR', () => {
       });
 
       interface Data {
-        currentUser: {
+        currentUser?: {
           firstName: string;
         };
       }
@@ -1290,7 +1290,7 @@ describe('SSR', () => {
       const Element = (props: { id: string }) => (
         <CurrentUserQuery query={query} ssr={false} variables={props}>
           {({ data, loading }) => (
-            <div>{loading || !data ? 'loading' : data.currentUser.firstName}</div>
+            <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
           )}
         </CurrentUserQuery>
       );

--- a/test/client/getDataFromTree.test.tsx
+++ b/test/client/getDataFromTree.test.tsx
@@ -531,19 +531,17 @@ describe('SSR', () => {
       });
 
       interface Data {
-        currentUser?: {
+        currentUser: {
           firstName: string;
         };
       }
 
       class CurrentUserQuery extends Query<Data> {}
 
-      const hasOwn = Object.prototype.hasOwnProperty;
-
       const WrappedElement = () => (
         <CurrentUserQuery query={query}>
-          {({ data, loading }: { data: Data; loading: boolean }) => (
-            <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
+          {({ data, loading }) => (
+            <div>{loading || !data ? 'loading' : data.currentUser.firstName}</div>
           )}
         </CurrentUserQuery>
       );
@@ -1282,7 +1280,7 @@ describe('SSR', () => {
       });
 
       interface Data {
-        currentUser?: {
+        currentUser: {
           firstName: string;
         };
       }
@@ -1291,8 +1289,8 @@ describe('SSR', () => {
 
       const Element = (props: { id: string }) => (
         <CurrentUserQuery query={query} ssr={false} variables={props}>
-          {({ data, loading }: { data: Data; loading: boolean }) => (
-            <div>{loading || !data ? 'loading' : data.currentUser!.firstName}</div>
+          {({ data, loading }) => (
+            <div>{loading || !data ? 'loading' : data.currentUser.firstName}</div>
           )}
         </CurrentUserQuery>
       );


### PR DESCRIPTION
https://github.com/apollographql/react-apollo/pull/1983 turned out to be breaking for many Typescript users. Rolling back those changes, and we'll find another way to get something similar in place.

Fixes https://github.com/apollographql/react-apollo/issues/2424.