### PR TITLE
Test changes to ensure type guard isn't needed on result `data`

### DIFF
--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -1476,4 +1476,24 @@ describe('Query component', () => {
       },
     );
   });
+
+  // https://github.com/apollographql/react-apollo/issues/2424
+  it('should be able to access data keys without a type guard', () => {
+    const Component = () => (
+      <AllPeopleQuery query={allPeopleQuery}>
+        {result => {
+          if (result.data && result.data.allPeople) {
+            return null;
+          }
+
+          if (result.data && result.data!.allPeople) {
+            return null;
+          }
+
+          const { allPeople } = result.data!;
+          return null;
+        }}
+      </AllPeopleQuery>
+    );
+  });
 });


### PR DESCRIPTION
#1983 introduced breaking changes that were missed by the current test suite. These changes were  rolled back in #2432, but the test changes in this PR should help prevent this same issue from happening again.

Reference: #2424