### PR TITLE
Update to `graphql@14`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@
 - Small `getDataFromTree.ts` logic adjustment to avoid unnecessary calls
   when a falsy `element` is encountered. <br/>
   [@HOUCe](https://github.com/HOUCe) in [#2429](https://github.com/apollographql/react-apollo/pull/2429)
+- `graphql` 14 updates. <br/>
+  [@hwillson](https://github.com/hwillson) in [#2437](https://github.com/apollographql/react-apollo/pull/2437)
 
 ## 2.2.2 (September 28, 2018)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,9 +173,9 @@
       "dev": true
     },
     "@types/graphql": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.7.tgz",
-      "integrity": "sha512-xuf/9ShwOOlxoV+J5ts4vAoPbL3nmcFU3z/Ad6jrsiB99hB/Wrs2fl3qJga5XJ1euAasMN/FsNPdHMV6+OV5vw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.0.1.tgz",
+      "integrity": "sha512-JnkzkyIHAjK7+zJLEQieQg5iDwEqoX200BBFa0rfMU7jI9BQWBnM9BZh16gQecCyBjK0S149wZPb0SoTh2o34g==",
       "dev": true
     },
     "@types/invariant": {
@@ -4084,12 +4084,12 @@
       "dev": true
     },
     "graphql": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
       "dev": true,
       "requires": {
-        "iterall": "^1.2.1"
+        "iterall": "^1.2.2"
       }
     },
     "graphql-anywhere": {

--- a/package.json
+++ b/package.json
@@ -88,12 +88,13 @@
   },
   "peerDependencies": {
     "apollo-client": "^2.3.8",
-    "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0"
+    "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.14",
     "@types/enzyme-adapter-react-16": "1.0.3",
-    "@types/graphql": "0.12.7",
+    "@types/graphql": "14.0.1",
     "@types/invariant": "2.2.29",
     "@types/jest": "23.3.2",
     "@types/lodash.flowright": "^3.5.4",
@@ -119,7 +120,7 @@
     "danger": "4.0.2",
     "enzyme": "3.6.0",
     "enzyme-adapter-react-16": "1.5.0",
-    "graphql": "0.13.2",
+    "graphql": "14.0.2",
     "graphql-tag": "2.9.2",
     "husky": "0.14.3",
     "jest": "23.6.0",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,7 +16,7 @@ export enum DocumentType {
 export interface IDocumentDefinition {
   type: DocumentType;
   name: string;
-  variables: VariableDefinitionNode[];
+  variables: ReadonlyArray<VariableDefinitionNode>;
 }
 
 const cache = new Map();


### PR DESCRIPTION
- Update dev dep to `graphql` 14.0.2
- Update `@types/graphql` to 14.0.1
- Add missing `graphql` peer dep, covering 0.11 to 14
