### PR TITLE
Move apollo-cache-inmemory to a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@types/recompose": "0.27.0",
     "@types/zen-observable": "0.8.0",
     "apollo-cache": "1.1.17",
-    "apollo-cache-inmemory": "1.2.10",
     "apollo-client": "2.4.2",
     "apollo-link": "1.2.1",
     "babel-core": "6.26.3",
@@ -146,6 +145,7 @@
     "zen-observable-ts": "0.8.10"
   },
   "dependencies": {
+    "apollo-cache-inmemory": "1.2.10",
     "fbjs": "^1.0.0",
     "hoist-non-react-statics": "^3.0.0",
     "invariant": "^2.2.2",


### PR DESCRIPTION
https://github.com/apollographql/react-apollo/blob/master/src/test-utils.tsx#L4 depends on `apollo-cache-inmemory`. When using the following in our tests:

```tsx
import { MockedProvider, MockedResponse } from 'react-apollo/test-utils';
```

The test suite fails with `Cannot find module 'apollo-cache-inmemory' from 'test-utils.js'`.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->