### PR TITLE
Patch networkStatus along with loading attribute

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Change log
 
+## vNext
+
+### Bug Fixes
+
+- Fix `networkStatus` to reflect the loading state correctly for partial 
+  refetching.  <br/>
+  [@steelbrain](https://github.com/steelbrain) in [#2493](https://github.com/apollographql/react-apollo/pull/2493)
+
 ## 2.2.4 (October 2, 2018)
 
 ### Bug Fixes

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -419,7 +419,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
           // the original `Query` component are expecting certain data values to
           // exist, and they're all of a sudden stripped away. To help avoid
           // this we'll attempt to refetch the `Query` data.
-          Object.assign(data, { loading: true });
+          Object.assign(data, { loading: true, networkStatus: NetworkStatus.loading });
           data.refetch();
           return data;
         }


### PR DESCRIPTION
This PR is a followup to https://github.com/apollographql/react-apollo/pull/2003

While the above mentioned PR set the `loading` status on the partial merged data, clients using the `networkStatus` to infer loading state were breaking still. This fixes `networkStatus` to reflect the loading state correctly for partial refetching, thus patching that hole.

Acknowledgements:

Thanks to @vafada for his help in investigating this

Edit: Rebased on master