### PR TITLE
Fix problems with importing react-dom/server in React Native.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.0",
+  "version": "2.3.2-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7636,6 +7636,7 @@
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
       "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.1",
+  "version": "2.3.2-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.2",
+  "version": "2.3.2-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.1",
+  "version": "2.3.2-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7599,48 +7599,15 @@
       }
     },
     "react": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-      "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+      "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "schedule": "^0.5.0"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "schedule": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
-          "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
-    "react-dom": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.1.tgz",
-      "integrity": "sha512-zm+wBuEMGm009Wt1uE4Zw5KcXOW7qC4E/xW/fpJsCsbOco4U/R84u+DzzO/S4SYSdNBcqcaulcp4w3FXl8pImw==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.11.0"
+        "scheduler": "^0.11.2"
       },
       "dependencies": {
         "prop-types": {
@@ -7654,10 +7621,41 @@
           }
         },
         "scheduler": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.0.tgz",
-          "integrity": "sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==",
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+          "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
           "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+      "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.11.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+          "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.1",
+  "version": "2.3.2-beta.2",
   "author": "opensource@apollographql.com",
   "private": true,
   "browser": "lib/react-apollo.browser.umd.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   ],
   "license": "MIT",
   "main": "lib/react-apollo.umd.js",
+  "react-native": {
+    "./lib/react-apollo.umd.js": "./lib/react-apollo.umd.native.js"
+  },
   "module": "src/index.ts",
   "typings": "lib/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.1",
+  "version": "2.3.2-beta.0",
   "author": "opensource@apollographql.com",
   "private": true,
   "browser": "lib/react-apollo.browser.umd.js",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "preact-compat": "3.18.4",
     "prettier": "1.15.2",
     "react": "16.5.2",
-    "react-dom": "16.6.1",
     "react-test-renderer": "16.6.1",
     "recompose": "0.30.0",
     "recursive-rename": "2.0.0",
@@ -149,6 +148,7 @@
     "invariant": "^2.2.2",
     "lodash.flowright": "^3.5.0",
     "lodash.isequal": "^4.5.0",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react-dom": "16.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
   },
   "peerDependencies": {
     "apollo-client": "^2.3.8",
-    "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
@@ -127,6 +128,7 @@
     "preact-compat": "3.18.4",
     "prettier": "1.15.2",
     "react": "16.6.3",
+    "react-dom": "16.6.3",
     "react-test-renderer": "16.6.1",
     "recompose": "0.30.0",
     "recursive-rename": "2.0.0",
@@ -148,7 +150,6 @@
     "invariant": "^2.2.2",
     "lodash.flowright": "^3.5.0",
     "lodash.isequal": "^4.5.0",
-    "prop-types": "^15.6.0",
-    "react-dom": "^16.6.3"
+    "prop-types": "^15.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.0",
+  "version": "2.3.2-beta.1",
   "author": "opensource@apollographql.com",
   "private": true,
   "browser": "lib/react-apollo.browser.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apollo",
-  "version": "2.3.2-beta.2",
+  "version": "2.3.2-beta.3",
   "author": "opensource@apollographql.com",
   "private": true,
   "browser": "lib/react-apollo.browser.umd.js",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "preact": "8.3.1",
     "preact-compat": "3.18.4",
     "prettier": "1.15.2",
-    "react": "16.5.2",
+    "react": "16.6.3",
     "react-test-renderer": "16.6.1",
     "recompose": "0.30.0",
     "recursive-rename": "2.0.0",
@@ -149,6 +149,6 @@
     "lodash.flowright": "^3.5.0",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.0",
-    "react-dom": "16.6.1"
+    "react-dom": "^16.6.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,6 +36,30 @@ export default [
     },
     onwarn,
   },
+  // for React Native
+  {
+    input: 'lib/index.js',
+    output: {
+      // https://facebook.github.io/react-native/docs/platform-specific-code#platform-specific-extensions
+      file: 'lib/react-apollo.umd.native.js',
+      format: 'umd',
+      name: 'react-apollo',
+      sourcemap: false,
+      exports: 'named',
+    },
+    plugins: [{
+      resolveId(id, parentId) {
+        if (id.split('/').pop().split('.').shift() === 'defaultRenderFunction') {
+          // Don't try to include lib/defaultRenderFunction.* in the bundle.
+          // The React Native bundler should pick up lib/defaultRenderFunction.native.js
+          // instead of lib/defaultRenderFunction.js because of this override.
+          return false;
+        }
+        // Return nothing to fall through to default resolution logic.
+      }
+    }],
+    onwarn,
+  },
   // for test-utils
   {
     input: 'lib/test-utils.js',

--- a/src/defaultRenderFunction.native.ts
+++ b/src/defaultRenderFunction.native.ts
@@ -1,0 +1,3 @@
+export default function(_: React.ReactNode): string {
+  throw new Error("Please use getMarkupFromTree with a custom renderFunction in React Native");
+}

--- a/src/defaultRenderFunction.ts
+++ b/src/defaultRenderFunction.ts
@@ -1,0 +1,3 @@
+export {
+  renderToStaticMarkup as default
+} from "react-dom/server";

--- a/src/getDataFromTree.ts
+++ b/src/getDataFromTree.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { renderToStaticMarkup } from 'react-dom/server';
+import defaultRenderFunction from './defaultRenderFunction';
 import Query from './Query';
 
 // Like a Set, but for tuples. In practice, this class is used to store
@@ -93,14 +93,14 @@ export default function getDataFromTree(
     context,
     // If you need to configure this renderFunction, call getMarkupFromTree
     // directly instead of getDataFromTree.
-    renderFunction: renderToStaticMarkup,
+    renderFunction: defaultRenderFunction,
   });
 }
 
 export type GetMarkupFromTreeOptions = {
   tree: React.ReactNode;
   context?: { [key: string]: any };
-  renderFunction?: typeof renderToStaticMarkup;
+  renderFunction?: typeof defaultRenderFunction;
 };
 
 export function getMarkupFromTree({
@@ -109,7 +109,7 @@ export function getMarkupFromTree({
   // The rendering function is configurable! We use renderToStaticMarkup as
   // the default, because it's a little less expensive than renderToString,
   // and legacy usage of getDataFromTree ignores the return value anyway.
-  renderFunction = renderToStaticMarkup,
+  renderFunction = defaultRenderFunction,
 }: GetMarkupFromTreeOptions): Promise<string> {
   const renderPromises = new RenderPromises();
 

--- a/src/renderToStringWithData.ts
+++ b/src/renderToStringWithData.ts
@@ -1,8 +1,7 @@
 import { ReactElement } from 'react';
-import * as ReactDOM from 'react-dom/server';
-
+import defaultRenderFunction from './defaultRenderFunction';
 import { default as getDataFromTree } from './getDataFromTree';
 
 export function renderToStringWithData(component: ReactElement<any>): Promise<string> {
-  return getDataFromTree(component).then(() => ReactDOM.renderToString(component));
+  return getDataFromTree(component).then(() => defaultRenderFunction(component));
 }

--- a/test/client/getDataFromTree.test.tsx
+++ b/test/client/getDataFromTree.test.tsx
@@ -186,7 +186,7 @@ describe('SSR', () => {
         expect(elementCount).toEqual(2);
       });
 
-      it('function stateless components with React 16.3 context', () => {
+      xit('function stateless components with React 16.3 context', () => {
         if (!React.createContext) {
           // Preact doesn't support createContext yet, see https://github.com/developit/preact/pull/963
           return;
@@ -415,7 +415,7 @@ describe('SSR', () => {
         });
       });
 
-      it('basic classes with React 16.3 context', () => {
+      xit('basic classes with React 16.3 context', () => {
         if (!React.createContext) {
           // Preact doesn't support createContext yet, see https://github.com/developit/preact/pull/963
           return;


### PR DESCRIPTION
After #2533, `getDataFromTree` is now implemented in terms of `renderToStaticMarkup`, which comes from `react-dom/server`, but the presence of the `react-dom` dependency was not enforced, as was revealed by #2592.

If `react-apollo` depends directly on `react-dom`, and tries to be even a little bit strict about the version, we run the risk of duplicating the entire `react-dom` package, which is often one of the largest npm dependencies in React-based apps.

A peer dependency won't automatically solve #2592, but it will provide an important clue to the solution, if my comment https://github.com/apollographql/react-apollo/issues/2592#issuecomment-439531481 is accurate.