### PR TITLE
Remove labels from GH templates since we're disabling Apollo Bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,13 +24,3 @@
 * [ ] Make sure all of the significant new logic is covered by tests
 * [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.
 
-<!--**Pull Request Labels**
-
-While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:
-
-- [ ] feature
-- [ ] blocking
-- [ ] docs
-
-To add a label not listed above, simply place `/label another-label-name` on a line by itself.
--->


### PR DESCRIPTION
Removing all mentions of labelling from this repos custom issue/PR templates (since we're no longer using Apollo Bot).
