### PR TITLE
Tell webpack to treeshake react-apollo

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
+  "sideEffects": false,
   "devDependencies": {
     "@types/enzyme": "3.1.15",
     "@types/enzyme-adapter-react-16": "1.0.3",


### PR DESCRIPTION
This allows consumers of react-apollo's [module distribution](https://github.com/apollographql/react-apollo/blob/master/package.json#L15) to use [webpack's treeshaking](https://github.com/GoodForOneFare/apollo-treeshake) feature.

I've created [a sample app](https://github.com/GoodForOneFare/apollo-treeshake) to demonstrate the before/after impact of treeshaking.  tl;dr: ~30KB (10KB gzipped) is saved by this change.

In our larger apps at Shopify, this change allows webpack to shake `react-dom/server.browser.js` out of client-side bundles (14KB unzipped / 5KB gzipped).