### PR TITLE
Allow webpack treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-apollo",
+  "name": "@shopify/react-apollo",
   "version": "2.0.4",
   "description": "React data container for Apollo Client",
   "module": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-apollo",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "React data container for Apollo Client",
   "module": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-apollo",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "React data container for Apollo Client",
   "module": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/react-apollo",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "React data container for Apollo Client",
   "module": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "@shopify/react-apollo",
-  "version": "2.0.7",
+  "name": "@goodforonefare/react-apollo",
+  "version": "2.0.7-tree-shake-7",
   "description": "React data container for Apollo Client",
   "module": "src/index.ts",
+  "sideEffects": false,
   "scripts": {
     "danger": "danger run --verbose",
     "deploy": "./scripts/prepare-package.sh && cd npm && npm publish",
@@ -119,7 +120,7 @@
     "fbjs": "^0.8.16",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.2",
-    "lodash": "4.17.4",
+    "lodash": "^4.17.4",
     "prop-types": "^15.6.0"
   }
 }

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,3 @@
+deploy:
+  override:
+    - npm run deploy

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -87,7 +87,10 @@ export interface OptionProps<TProps, TResult> {
   mutate: MutationFunc<TResult>;
 }
 
-export type OptionDescription<P> = QueryOpts | MutationOpts | ((props: P) => QueryOpts | MutationOpts);
+export type OptionDescription<P> =
+  | QueryOpts
+  | MutationOpts
+  | ((props: P) => QueryOpts | MutationOpts);
 
 export type NamedProps<P, R> = P & {
   ownProps: R,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "es2015",
-    "target": "es2015",
+    "target": "es5",
     "lib": ["es2015", "dom"],
     "moduleResolution": "node",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,7 +3265,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@4.17.4, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Adding `sideEffects` to package.json tells webpack that it's safe to remove unused imports from this library.  This allows it to shake out react-dom/

Mainline apollo has already merged this change (https://github.com/apollographql/react-apollo/pull/2616).

-----

web before (note that react-dom/server-browser is in the main.js bundle here):

<img width="735" alt="webpack bundle analyzer 2018-12-05 15-34-17" src="https://user-images.githubusercontent.com/673655/49524223-45404e00-f8a3-11e8-8f69-7c0ce87140c8.png">

-----

web after (react-dom/server-browser is now buried in an analytics bundle):

<img width="771" alt="webpack bundle analyzer 2018-12-05 15-35-26" src="https://user-images.githubusercontent.com/673655/49524327-76b91980-f8a3-11e8-9c3b-d761fa19189b.png">
