### PR TITLE
awaitRefetchQueries defaultOption not being respected by the Mutation component

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -184,19 +184,19 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
       });
   };
 
-  private mutate = (options: MutationOptions<TData, TVariables>) => {
+  private mutate = (options: MutationOptions<TData, TVariables> = {}) => {
     const {
       mutation,
       variables,
       optimisticResponse,
       update,
       context = {},
-      awaitRefetchQueries = false,
+      awaitRefetchQueries = (this.client.defaultOptions.mutate && this.client.defaultOptions.mutate.awaitRefetchQueries) || false,
       fetchPolicy,
     } = this.props;
-    const mutateOptions = { ...options };
 
-    let refetchQueries = mutateOptions.refetchQueries || this.props.refetchQueries;
+    const mutateOptions = { ...options };
+    let refetchQueries =  mutateOptions.refetchQueries || this.props.refetchQueries;
     // XXX this will be removed in the 3.0 of Apollo Client. Currently, we
     // support refectching of named queries which just pulls the latest
     // variables to match. This forces us to either a) keep all queries around


### PR DESCRIPTION
### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

In the issue: https://github.com/apollographql/react-apollo/issues/2643

It was brought to my attention that the defaultOptions provided to the ApolloClient are not respected by react-apollo. That is why I opted to fix this and add a test for it.

