### PR TITLE
Invoke onCompleted/onError even if Mutiation unmounts

### DIFF
--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -242,9 +242,6 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
   };
 
   private onMutationCompleted = (response: ExecutionResult<TData>, mutationId: number) => {
-    if (this.hasMounted === false) {
-      return;
-    }
     const { onCompleted, ignoreResults } = this.props;
 
     const { data, errors } = response;
@@ -253,7 +250,7 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
 
     const callOncomplete = () => (onCompleted ? onCompleted(data as TData) : null);
 
-    if (this.isMostRecentMutation(mutationId) && !ignoreResults) {
+    if (this.hasMounted && this.isMostRecentMutation(mutationId) && !ignoreResults) {
       this.setState({ loading: false, data, error }, callOncomplete);
     } else {
       callOncomplete();
@@ -261,13 +258,10 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
   };
 
   private onMutationError = (error: ApolloError, mutationId: number) => {
-    if (this.hasMounted === false) {
-      return;
-    }
     const { onError } = this.props;
     const callOnError = () => (onError ? onError(error) : null);
 
-    if (this.isMostRecentMutation(mutationId)) {
+    if (this.hasMounted && this.isMostRecentMutation(mutationId)) {
       this.setState({ loading: false, error }, callOnError);
     } else {
       callOnError();

--- a/test/client/Mutation.test.tsx
+++ b/test/client/Mutation.test.tsx
@@ -1477,11 +1477,13 @@ it('errors when changing from mutation to a subscription', done => {
 });
 
 it('does not update state after receiving data after it has been unmounted', done => {
+  const onCompleted = jest.fn();
   let success = false;
   let original = console.error;
   console.error = jest.fn();
   const checker = () => {
     setTimeout(() => {
+      expect(onCompleted).toHaveBeenCalled();
       expect(console.error).not.toHaveBeenCalled();
       console.error = original;
       success = true;
@@ -1500,7 +1502,7 @@ it('does not update state after receiving data after it has been unmounted', don
         return null;
       } else {
         return (
-          <Mutation mutation={mutation}>
+          <Mutation mutation={mutation} onCompleted={onCompleted}>
             {(createTodo, result) => {
               if (!result.called) {
                 setTimeout(() => {
@@ -1529,10 +1531,12 @@ it('does not update state after receiving data after it has been unmounted', don
 });
 
 it('does not update state after receiving error after it has been unmounted', done => {
+  const onError = jest.fn();
   let original = console.error;
   console.error = jest.fn();
   const checker = () => {
     setTimeout(() => {
+      expect(onError).toHaveBeenCalled();
       expect(console.error).not.toHaveBeenCalled();
       console.error = original;
       done();
@@ -1550,7 +1554,7 @@ it('does not update state after receiving error after it has been unmounted', do
         return null;
       } else {
         return (
-          <Mutation mutation={mutation}>
+          <Mutation mutation={mutation} onError={onError}>
             {(createTodo, result) => {
               if (!result.called) {
                 setTimeout(() => {

--- a/test/client/Mutation.test.tsx
+++ b/test/client/Mutation.test.tsx
@@ -1476,111 +1476,210 @@ it('errors when changing from mutation to a subscription', done => {
   console.log = errorLogger; // tslint:disable-line
 });
 
-it('does not update state after receiving data after it has been unmounted', done => {
-  const onCompleted = jest.fn();
-  let success = false;
-  let original = console.error;
-  console.error = jest.fn();
-  const checker = () => {
-    setTimeout(() => {
-      expect(onCompleted).toHaveBeenCalled();
-      expect(console.error).not.toHaveBeenCalled();
-      console.error = original;
-      success = true;
-      done();
-    }, 100);
-  };
-
-  class Component extends React.Component {
-    state = {
-      called: false,
+describe('after it has been unmounted', () => {
+  it('calls the onCompleted prop after the mutation is complete', done => {
+    let success = false;
+    const onCompletedFn = jest.fn();
+    const checker = () => {
+      setTimeout(() => {
+        success = true;
+        expect(onCompletedFn).toHaveBeenCalledWith(data);
+        done();
+      }, 100);
     };
 
-    render() {
-      const { called } = this.state;
-      if (called === true) {
-        return null;
-      } else {
-        return (
-          <Mutation mutation={mutation} onCompleted={onCompleted}>
-            {(createTodo, result) => {
-              if (!result.called) {
+    class Component extends React.Component {
+      state = {
+        called: false,
+      };
+
+      render() {
+        const { called } = this.state;
+        if (called === true) {
+          return null;
+        } else {
+          return (
+            <Mutation mutation={mutation} onCompleted={onCompletedFn}>
+              {createTodo => {
                 setTimeout(() => {
                   createTodo();
                   this.setState({ called: true }, checker);
                 });
-              }
-
-              return null;
-            }}
-          </Mutation>
-        );
+                return null;
+              }}
+            </Mutation>
+          );
+        }
       }
     }
-  }
 
-  mount(
-    <MockedProvider mocks={mocks}>
-      <Component />
-    </MockedProvider>,
-  );
+    mount(
+      <MockedProvider mocks={mocks}>
+        <Component />
+      </MockedProvider>,
+    );
 
-  setTimeout(() => {
-    if (!success) done.fail('timeout passed');
-  }, 200);
-});
-
-it('does not update state after receiving error after it has been unmounted', done => {
-  const onError = jest.fn();
-  let original = console.error;
-  console.error = jest.fn();
-  const checker = () => {
     setTimeout(() => {
-      expect(onError).toHaveBeenCalled();
-      expect(console.error).not.toHaveBeenCalled();
-      console.error = original;
-      done();
-    }, 100);
-  };
+      if (!success) done.fail('timeout passed');
+    }, 200);
+  });
 
-  class Component extends React.Component {
-    state = {
-      called: false,
+  it('calls the onError prop if the mutation encounters an error', done => {
+    let success = false;
+    const onErrorFn = jest.fn();
+    const checker = () => {
+      setTimeout(() => {
+        success = true;
+        expect(onErrorFn).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'Network error: error occurred' }),
+        );
+        done();
+      }, 100);
     };
 
-    render() {
-      const { called } = this.state;
-      if (called === true) {
-        return null;
-      } else {
-        return (
-          <Mutation mutation={mutation} onError={onError}>
-            {(createTodo, result) => {
-              if (!result.called) {
-                setTimeout(() => {
-                  createTodo().catch(() => {}); // tslint:disable-line
-                  this.setState({ called: true }, checker);
-                }, 10);
-              }
+    class Component extends React.Component {
+      state = {
+        called: false,
+      };
 
-              return null;
-            }}
-          </Mutation>
-        );
+      render() {
+        const { called } = this.state;
+        if (called === true) {
+          return null;
+        } else {
+          return (
+            <Mutation mutation={mutation} onError={onErrorFn}>
+              {createTodo => {
+                setTimeout(() => {
+                  createTodo();
+                  this.setState({ called: true }, checker);
+                });
+                return null;
+              }}
+            </Mutation>
+          );
+        }
       }
     }
-  }
 
-  const mockError = [
-    {
-      request: { query: mutation },
-      error: new Error('error occurred'),
-    },
-  ];
+    const mockError = [
+      {
+        request: { query: mutation },
+        error: new Error('error occurred'),
+      },
+    ];
 
-  const wrapper = mount(
-    <MockedProvider mocks={mockError}>
-      <Component />
-    </MockedProvider>,
-  );
+    mount(
+      <MockedProvider mocks={mockError}>
+        <Component />
+      </MockedProvider>,
+    );
+  });
+
+  it('does not update state after receiving data', done => {
+    let success = false;
+    let original = console.error;
+    console.error = jest.fn();
+    const checker = () => {
+      setTimeout(() => {
+        expect(console.error).not.toHaveBeenCalled();
+        console.error = original;
+        success = true;
+        done();
+      }, 100);
+    };
+
+    class Component extends React.Component {
+      state = {
+        called: false,
+      };
+
+      render() {
+        const { called } = this.state;
+        if (called === true) {
+          return null;
+        } else {
+          return (
+            <Mutation mutation={mutation}>
+              {(createTodo, result) => {
+                if (!result.called) {
+                  setTimeout(() => {
+                    createTodo();
+                    this.setState({ called: true }, checker);
+                  });
+                }
+
+                return null;
+              }}
+            </Mutation>
+          );
+        }
+      }
+    }
+
+    mount(
+      <MockedProvider mocks={mocks}>
+        <Component />
+      </MockedProvider>,
+    );
+
+    setTimeout(() => {
+      if (!success) done.fail('timeout passed');
+    }, 200);
+  });
+
+  it('does not update state after receiving error', done => {
+    const onError = jest.fn();
+    let original = console.error;
+    console.error = jest.fn();
+    const checker = () => {
+      setTimeout(() => {
+        expect(onError).toHaveBeenCalled();
+        expect(console.error).not.toHaveBeenCalled();
+        console.error = original;
+        done();
+      }, 100);
+    };
+
+    class Component extends React.Component {
+      state = {
+        called: false,
+      };
+
+      render() {
+        const { called } = this.state;
+        if (called === true) {
+          return null;
+        } else {
+          return (
+            <Mutation mutation={mutation} onError={onError}>
+              {(createTodo, result) => {
+                if (!result.called) {
+                  setTimeout(() => {
+                    createTodo().catch(() => {}); // tslint:disable-line
+                    this.setState({ called: true }, checker);
+                  }, 10);
+                }
+
+                return null;
+              }}
+            </Mutation>
+          );
+        }
+      }
+    }
+
+    const mockError = [
+      {
+        request: { query: mutation },
+        error: new Error('error occurred'),
+      },
+    ];
+
+    const wrapper = mount(
+      <MockedProvider mocks={mockError}>
+        <Component />
+      </MockedProvider>,
+    );
+  });
 });


### PR DESCRIPTION
Closes #2293 [(Query onCompleted not invoked)](https://github.com/apollographql/react-apollo/issues/2293)

## The issue

When passing both `onCompleted` and `refetchQueries` to a `Mutation` that un-mounts as a result of `refetchQueries`, `onCompleted` will never be called.

Consider the following example:

A logout button that invokes a mutation, which re-fetches a query to propagate this change to the rest of the app (e.g. removing references to the currently logged-in user).

On that mutation, we have an `onCompleted` to redirect to the login page after both _a successful logout mutation_ AND _a successful refetch_ .

With the current implementation, `onCompleted` will never be called because as soon as `refetchQueries` is finished, the logout mutation will unmount and the redirect will never happen.

```jsx
{loggedIn && ( // ← mutation rendering is conditional 
  <Mutation
    awaitRefetchQueries
    mutation={logoutMutation}
    refetchQueries={[/* a query to update the current user info (e.g. loggedIn) */]}
    onCompleted={redirectToLogin /* this callback will never be called */}
  >
    {/* a logout button to run the mutation when clicked */}
  </Mutation>
)}
```

This might not be the best example, but hopefully it can demonstrate the real issue the PR is trying to address.

### Replicating the Issue

I was able to replicate this issue easily when I tried to pass an `onCompleted` callback to the Mutation in this test and assert that it was called:
 - https://github.com/apollographql/react-apollo/blob/master/test/client/Mutation.test.tsx#L1479-L1518

## The Cause

It appears that this is intentional in order to avoid updating the Mutation internal state after it un-mounts.

https://github.com/apollographql/react-apollo/blob/cce02a346643a2cea5547304d56f2e2f05b74fcd/src/Mutation.tsx#L244-L247

Unless I'm missing something here or there is a reason not do so, this doesn't necessarily mean that an `onCompleted` callback should never be called when a mutation is resolved and has been unmounted.

While it can be hard to think that an unmounted component would have callbacks called, it is important to keep in mind that consumers of an unmounted Mutation have no indication to when the said mutation is resolved successfully or when its refetched queries are finished (same for errors).

## Possible Fix

By changing the logic of [`onMutationCompleted`](https://github.com/apollographql/react-apollo/blob/cce02a346643a2cea5547304d56f2e2f05b74fcd/src/Mutation.tsx#L244-L261) a little bit, it looks like it's possible to invoke the user-provided `onComplete` even when the `Mutation` unmounts.

I also went ahead and applied the same changes to `onError`/`onMutationError` for consistency.
