### PR TITLE
remove connection directive before creating mock key

### DIFF
--- a/src/test-links.ts
+++ b/src/test-links.ts
@@ -8,7 +8,7 @@ import {
 } from 'apollo-link';
 
 import { print } from 'graphql/language/printer';
-import { addTypenameToDocument } from 'apollo-utilities';
+import { addTypenameToDocument, removeConnectionDirectiveFromDocument } from 'apollo-utilities';
 const isEqual = require('lodash.isequal');
 
 export interface MockedResponse {
@@ -143,8 +143,10 @@ export class MockSubscriptionLink extends ApolloLink {
 }
 
 function requestToKey(request: GraphQLRequest, addTypename: Boolean): string {
+  const withoutConnection = request.query && removeConnectionDirectiveFromDocument(request.query);
   const queryString =
-    request.query && print(addTypename ? addTypenameToDocument(request.query) : request.query);
+    withoutConnection &&
+    print(addTypename ? addTypenameToDocument(withoutConnection) : withoutConnection);
 
   const requestKey = { query: queryString };
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fixes #2719 

Before a query is sent by the Apollo client, the `@connection` directive is stripped out. To save people from having to make two queries that very close match for the sake of a `request.query`, I think the mocked request queries should have the same transformation applied

### Checklist:

* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

