### PR TITLE
Fix type definition for QueryResult data property

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -75,13 +75,14 @@ export interface QueryResult<TData = any, TVariables = OperationVariables>
   // I'm aware of. So intead we enforce checking for data
   // like so result.data!.user. This tells TS to use TData
   // XXX is there a better way to do this?
-  data: TData | undefined;
+  data: Partial<TData>;
   error?: ApolloError;
   loading: boolean;
   networkStatus: NetworkStatus;
 }
 
-export interface QueryProps<TData = any, TVariables = OperationVariables> extends QueryOpts<TVariables> {
+export interface QueryProps<TData = any, TVariables = OperationVariables>
+  extends QueryOpts<TVariables> {
   children: (result: QueryResult<TData, TVariables>) => React.ReactNode;
   query: DocumentNode;
   displayName?: string;

--- a/src/query-hoc.tsx
+++ b/src/query-hoc.tsx
@@ -87,7 +87,7 @@ export function withQuery<
               // we massage the Query components shape here to replicate that
               const result = Object.assign(r, data || {});
               const name = operationOptions.name || 'data';
-              let childProps = { [name]: result };
+              let childProps: { [x: string]: any | undefined } = { [name]: result };
               if (operationOptions.props) {
                 const newResult: OptionProps<TProps, TData, TGraphQLVariables> = {
                   [name]: result,


### PR DESCRIPTION
Query result is an empty object or TData, not undefined or TData.

I ran into a problem with the current type definition.

```tsx
interface MyResult {
  item: {
    name: string;
  };
}

<Query<MyResult, ..>>
{({ data }) => {
  // The old type of data would be MyResult | undefined so I unwrap it like this:
  const name = data && data.item.name || 'default name'
  // TypeError: Cannot read property 'name' of undefined
}}
</Query>
```

[Partial](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types) makes each of its generic type's properties optional

I could ofcourse change my TData type to have optional keys:

```ts
interface MyResult {
  item?: {
    name: string;
  };
}
```

But then it doesn't directly reflect what response my graphql server gives, and in my case the types are generated..