### PR TITLE
Use ApolloClient#stop to clean up MockedProvider client.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -696,9 +696,9 @@
       }
     },
     "apollo-client": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.11.tgz",
-      "integrity": "sha512-sySR4+k9CbMVHy0Yj3jjbCq+DKsRlCcjW8UBiOzWOhkcfvMBo27TYR2xPfzFLj3YZtfzeDkx6O9GiHJ8FY+6uA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.12.tgz",
+      "integrity": "sha512-E5ClFSB9btJLYibLKwLDSCg+w9tI+25eZgXOM+DClawu7of4d/xhuV/xvpuZpsMP3qwrp0QPacBnfG4tUJs3/w==",
       "dev": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "trailingComma": "all"
   },
   "peerDependencies": {
-    "apollo-client": "^2.3.8",
+    "apollo-client": "^2.4.12",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
@@ -111,7 +111,7 @@
     "@types/zen-observable": "0.8.0",
     "apollo-cache": "^1.1.25",
     "apollo-cache-inmemory": "^1.4.2",
-    "apollo-client": "^2.4.11",
+    "apollo-client": "^2.4.12",
     "apollo-link": "1.2.1",
     "babel-core": "6.26.3",
     "babel-jest": "23.6.0",

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -42,15 +42,8 @@ export class MockedProvider extends React.Component<MockedProviderProps, MockedP
   }
 
   public componentWillUnmount() {
-    if (!this.state.client.queryManager) {
-      return;
-    }
-    const scheduler = this.state.client.queryManager.scheduler;
-    Object.keys(scheduler.registeredQueries).forEach(queryId => {
-      scheduler.stopPollingQuery(queryId);
-    });
-    Object.keys(scheduler.intervalQueries).forEach((interval: any) => {
-      scheduler.fetchQueriesOnInterval(interval);
-    });
+    // Since this.state.client was created in the constructor, it's this
+    // MockedProvider's responsibility to terminate it.
+    this.state.client.stop();
   }
 }


### PR DESCRIPTION
This `stop` method was introduced in apollo-client@2.4.12: https://github.com/apollographql/apollo-client/pull/4336

Credit to @danilobuerger for suggesting we hide the details of stopping the `MockedProvider` client using a new `ApolloClient` method: https://apollographql.slack.com/archives/C2FERSTGC/p1547849096341900

The `stop` method would have made https://github.com/apollographql/react-apollo/issues/2738 a non-issue, since we could easily change the implementation of `stop` without affecting its consumers.