### PR TITLE
fix: When doing a SSR with errorPolicy='all', then error should not be lost

### DIFF
--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -172,6 +172,12 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
       ...opts,
       fetchPolicy,
     });
+
+    // Register the SSR observable, so it can be re-used once the value comes back.
+    if (this.context && this.context.renderPromises) {
+      this.context.renderPromises.registerSSRObservable(this, observable);
+    }
+
     const result = this.queryObservable!.currentResult();
 
     return result.loading ? observable.result() : false;
@@ -284,7 +290,16 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
     const opts = this.extractOptsFromProps(props);
     // save for backwards compat of refetcherQueries without a recycler
     this.setOperations(opts);
-    this.queryObservable = this.client.watchQuery(opts);
+
+    // See if there is an existing observable that was used to fetch the same data and
+    // if so, use it instead since it will contain the proper queryId to fetch
+    // the result set. This is used during SSR.
+    if (this.context && this.context.renderPromises) {
+      this.queryObservable = this.context.renderPromises.getSSRObservable(this);
+    }
+    if (!this.queryObservable) {
+      this.queryObservable = this.client.watchQuery(opts);
+    }
   }
 
   private setOperations(props: QueryProps<TData, TVariables>) {


### PR DESCRIPTION
Closes #2680
Closes #2134
Closes #1972
Closes #1781 
Closes #615

This change tracks the original observable used during a SSR. When the Query component is recreated due to a Query's promise resolving, then the original queryId used to track the response error is lost. By tracking the original observable, the newly instantiated Query component can reference the original observable to retrieve the actual result. This makes the feature work like the documentation states, which allows server side rendered components to properly handle errors rather than throwing exceptions.

