### PR TITLE
Changes to accommodate AC's integrated local state handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -763,7 +763,6 @@
       "version": "1.2.0-beta.0",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.0-beta.0.tgz",
       "integrity": "sha512-NVPp5+iulBqkFqOJj3ABddDj4K3/nMh08iVBT1P2O3O0mer+ldLPJWJI02HDcu81uGQUk3StBn06V9Ja751zRQ==",
-      "dev": true,
       "requires": {
         "fast-json-stable-stringify": "^2.0.0",
         "tslib": "^1.9.3"
@@ -3359,8 +3358,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,133 +693,81 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.25",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.25.tgz",
-      "integrity": "sha512-9HhI/tVEHAeGaJJvi1Vpf6PzXUCA0PqNbigi2G3uOc180JjxbcaBvEbKXMEDb/UyTXkFWzI4PiPDuDQFqmIMSA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.2.0-beta.0.tgz",
+      "integrity": "sha512-MIkqjZcej+GhCWJjHCU/qR8cHB+gS36+ZIollp76tfOva0xTxEE1hxdJUQLEKkKI/V522jozexIEW6DjORJn+Q==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.1.2",
+        "apollo-utilities": "^1.2.0-beta.0",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.2.tgz",
-          "integrity": "sha512-EjDx8vToK+zkWIxc76ZQY/irRX52puNg04xf/w8R0kVTDAgHuVfnFVC01O5vE25kFnIaa5em0pFI0p9b6YMkhQ==",
-          "dev": true,
-          "requires": {
-            "fast-json-stable-stringify": "^2.0.0",
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.4.2.tgz",
-      "integrity": "sha512-fDVmj5j1e3W+inyuSwjIcMgbQ4edcFgmiKTBMFAEKAq0jg33X7FrbDX8JT2t5Vuf75Mva50JDlt5wXdu7C6WuA==",
+      "version": "1.5.0-beta.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.5.0-beta.0.tgz",
+      "integrity": "sha512-fUhM4l1rBI/4ITMIniaUNL1Ktirf0iH6nKzvnQV7W0noPSOI1zSOibgQ1fpS/vr194QkU+bD3DbrCd7OeRXcag==",
       "dev": true,
       "requires": {
-        "apollo-cache": "^1.1.25",
-        "apollo-utilities": "^1.1.2",
+        "apollo-cache": "^1.2.0-beta.0",
+        "apollo-utilities": "^1.2.0-beta.0",
         "optimism": "^0.6.9",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.2.tgz",
-          "integrity": "sha512-EjDx8vToK+zkWIxc76ZQY/irRX52puNg04xf/w8R0kVTDAgHuVfnFVC01O5vE25kFnIaa5em0pFI0p9b6YMkhQ==",
-          "dev": true,
-          "requires": {
-            "fast-json-stable-stringify": "^2.0.0",
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "apollo-client": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.12.tgz",
-      "integrity": "sha512-E5ClFSB9btJLYibLKwLDSCg+w9tI+25eZgXOM+DClawu7of4d/xhuV/xvpuZpsMP3qwrp0QPacBnfG4tUJs3/w==",
+      "version": "2.5.0-beta.0",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.5.0-beta.0.tgz",
+      "integrity": "sha512-Tj2P0eIci2zE3HuoPqhPLb11RydXfRyzEmDFg4WS5tnCPOc163sOV4+i6530MT3Ve9Dc7U12DdXfGnQ+6yY/fA==",
       "dev": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.1.25",
+        "apollo-cache": "1.2.0-beta.0",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "1.1.2",
+        "apollo-utilities": "1.2.0-beta.0",
         "symbol-observable": "^1.0.2",
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.2.tgz",
-          "integrity": "sha512-EjDx8vToK+zkWIxc76ZQY/irRX52puNg04xf/w8R0kVTDAgHuVfnFVC01O5vE25kFnIaa5em0pFI0p9b6YMkhQ==",
-          "dev": true,
-          "requires": {
-            "fast-json-stable-stringify": "^2.0.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "zen-observable": {
-          "version": "0.8.11",
-          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
-          "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==",
-          "dev": true
-        }
       }
     },
     "apollo-link": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz",
-      "integrity": "sha512-6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
+      "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
       "dev": true,
       "requires": {
-        "@types/node": "^9.4.6",
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.6"
+        "zen-observable-ts": "^0.8.15"
       },
       "dependencies": {
         "zen-observable-ts": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.8.tgz",
-          "integrity": "sha512-oGjFvBbAA94uh/HvAwJDwMHtNq4lZRtupJx8XsyreOTYvH8x1ef9hIeH/M+IqiAXtNpglq/Klh5rbpYWEeRSOQ==",
+          "version": "0.8.15",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
+          "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
           "dev": true,
           "requires": {
-            "zen-observable": "^0.7.0"
+            "zen-observable": "^0.8.0"
           }
         }
       }
     },
     "apollo-link-dedup": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.13.tgz",
-      "integrity": "sha512-i4NuqT3DSFczFcC7NMUzmnYjKX7NggLY+rqYVf+kE9JjqKOQhT6wqhaWsVIABfIUGE/N0DTgYJBCMu/18aXmYA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.15.tgz",
+      "integrity": "sha512-14/+Tg7ogcYVrvZa8C7uBQIvX2B/dCKSnojI41yDYGp/t2eWD5ITCWdgjhciXpi0Ij6z+NRyMEebACz3EOwm4w==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.6"
-      },
-      "dependencies": {
-        "apollo-link": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.6.tgz",
-          "integrity": "sha512-sUNlA20nqIF3gG3F8eyMD+mO80fmf3dPZX+GUOs3MI9oZR8ug09H3F0UsWJMcpEg6h55Yy5wZ+BMmAjrbenF/Q==",
-          "dev": true,
-          "requires": {
-            "apollo-utilities": "^1.0.0",
-            "zen-observable-ts": "^0.8.13"
-          }
-        }
+        "apollo-link": "^1.2.8"
       }
     },
     "apollo-utilities": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.8.tgz",
-      "integrity": "sha512-EvqRJCw5xy2gWeH37toUimbEkmUxronCosBNE4tOCJvZUMLLGB8CuTQ5RsBhKJm+rZ6kwGxV+2uszk14f/P/rA==",
-      "dev": true
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.0-beta.0.tgz",
+      "integrity": "sha512-NVPp5+iulBqkFqOJj3ABddDj4K3/nMh08iVBT1P2O3O0mer+ldLPJWJI02HDcu81uGQUk3StBn06V9Ja751zRQ==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.9.3"
+      }
     },
     "append-transform": {
       "version": "0.4.0",
@@ -3591,8 +3539,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3616,15 +3563,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3641,22 +3586,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3787,8 +3729,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3802,7 +3743,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3819,7 +3759,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3828,15 +3767,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3857,7 +3794,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3946,8 +3882,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3961,7 +3896,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4057,8 +3991,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4100,7 +4033,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4122,7 +4054,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4171,15 +4102,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10969,9 +10898,9 @@
       }
     },
     "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
+      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g==",
       "dev": true
     },
     "zen-observable-ts": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "trailingComma": "all"
   },
   "peerDependencies": {
-    "apollo-client": "^2.4.12",
+    "apollo-client": "beta",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
@@ -107,10 +107,10 @@
     "@types/react-test-renderer": "16.0.3",
     "@types/recompose": "0.30.3",
     "@types/zen-observable": "0.8.0",
-    "apollo-cache": "^1.1.25",
-    "apollo-cache-inmemory": "^1.4.2",
-    "apollo-client": "^2.4.12",
-    "apollo-link": "1.2.1",
+    "apollo-cache": "beta",
+    "apollo-cache-inmemory": "beta",
+    "apollo-client": "beta",
+    "apollo-link": "1.2.8",
     "babel-core": "6.26.3",
     "babel-jest": "23.6.0",
     "babel-preset-env": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "zen-observable-ts": "0.8.13"
   },
   "dependencies": {
+    "apollo-utilities": "beta",
     "hoist-non-react-statics": "^3.0.0",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.0",

--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -35,14 +35,19 @@ export declare type MutationUpdaterFn<
   }
 > = (proxy: DataProxy, mutationResult: FetchResult<T>) => void;
 
-export declare type FetchResult<C = Record<string, any>, E = Record<string, any>> = ExecutionResult<
-  C
-> & {
+export declare type FetchResult<
+  TData = Record<string, any>,
+  C = Record<string, any>,
+  E = Record<string, any>
+> = ExecutionResult<TData> & {
   extensions?: E;
   context?: C;
 };
 
-export declare type MutationOptions<TData = any, TVariables = OperationVariables> = {
+export declare type MutationOptions<
+  TData = { [key: string]: any },
+  TVariables = OperationVariables
+> = {
   variables?: TVariables;
   optimisticResponse?: TData;
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesProviderFn;
@@ -174,11 +179,11 @@ class Mutation<TData = any, TVariables = OperationVariables> extends React.Compo
     const mutationId = this.generateNewMutationId();
 
     return this.mutate(options)
-      .then(response => {
+      .then((response: ExecutionResult<TData>) => {
         this.onMutationCompleted(response, mutationId);
         return response;
       })
-      .catch(e => {
+      .catch((e: ApolloError) => {
         this.onMutationError(e, mutationId);
         if (!this.props.onError) throw e;
       });

--- a/src/Mutation.tsx
+++ b/src/Mutation.tsx
@@ -45,7 +45,7 @@ export declare type FetchResult<
 };
 
 export declare type MutationOptions<
-  TData = { [key: string]: any },
+  TData = Record<string, any>,
   TVariables = OperationVariables
 > = {
   variables?: TVariables;

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -198,7 +198,6 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
   componentWillReceiveProps(nextProps: QueryProps<TData, TVariables>, nextContext: QueryContext) {
     // the next render wants to skip
     if (nextProps.skip && !this.props.skip) {
-      this.lastResult = this.queryObservable!.getLastResult();
       this.removeQuerySubscription();
       return;
     }

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -135,7 +135,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
 
   private hasMounted: boolean = false;
   private operation?: IDocumentDefinition;
-  private lastResult?: ApolloQueryResult<TData> | null;
+  private lastResult: ApolloQueryResult<TData> | null = null;
 
   constructor(props: QueryProps<TData, TVariables>, context: QueryContext) {
     super(props, context);

--- a/src/hoc-utils.tsx
+++ b/src/hoc-utils.tsx
@@ -15,8 +15,6 @@ export function getDisplayName<P>(WrappedComponent: React.ComponentType<P>) {
 export function calculateVariablesFromProps<TProps>(
   operation: IDocumentDefinition,
   props: TProps,
-  graphQLDisplayName: string,
-  wrapperName: string,
 ) {
   let variables: OperationVariables = {};
   for (let { variable, type } of operation.variables) {
@@ -30,19 +28,10 @@ export function calculateVariablesFromProps<TProps>(
       continue;
     }
 
-    // allow optional props
+    // Allow optional props
     if (type.kind !== 'NonNullType') {
       variables[variableName] = null;
-      continue;
     }
-
-    if (operation.type === DocumentType.Mutation) return;
-    invariant(
-      typeof variableProp !== 'undefined',
-      `The operation '${operation.name}' wrapping '${wrapperName}' ` +
-        `is expecting a variable: '${variable.name.value}' but it was not found in the props ` +
-        `passed to '${graphQLDisplayName}'`,
-    );
   }
   return variables;
 }

--- a/src/mutation-hoc.tsx
+++ b/src/mutation-hoc.tsx
@@ -51,8 +51,6 @@ export function withMutation<
           opts.variables = calculateVariablesFromProps(
             operation,
             props,
-            graphQLDisplayName,
-            getDisplayName(WrappedComponent),
           );
         }
 

--- a/src/query-hoc.tsx
+++ b/src/query-hoc.tsx
@@ -61,8 +61,6 @@ export function withQuery<
           opts.variables = calculateVariablesFromProps(
             operation,
             props,
-            graphQLDisplayName,
-            getDisplayName(WrappedComponent),
           );
         }
         return (

--- a/src/subscription-hoc.tsx
+++ b/src/subscription-hoc.tsx
@@ -67,8 +67,6 @@ export function withSubscription<
           opts.variables = calculateVariablesFromProps(
             operation,
             props,
-            graphQLDisplayName,
-            getDisplayName(WrappedComponent),
           );
         }
         return (

--- a/src/test-links.ts
+++ b/src/test-links.ts
@@ -8,7 +8,10 @@ import {
 } from 'apollo-link';
 
 import { print } from 'graphql/language/printer';
-import { addTypenameToDocument } from 'apollo-utilities';
+import {
+  addTypenameToDocument,
+  removeClientSetsFromDocument,
+} from 'apollo-utilities';
 const isEqual = require('lodash.isequal');
 
 export interface MockedResponse {
@@ -144,11 +147,10 @@ export class MockSubscriptionLink extends ApolloLink {
 }
 
 function requestToKey(request: GraphQLRequest, addTypename: Boolean): string {
+  const query = removeClientSetsFromDocument(request.query);
   const queryString =
-    request.query && print(addTypename ? addTypenameToDocument(request.query) : request.query);
-
+    query && print(addTypename ? addTypenameToDocument(query) : query);
   const requestKey = { query: queryString };
-
   return JSON.stringify(requestKey);
 }
 

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ApolloClient from 'apollo-client';
-import { DefaultOptions } from 'apollo-client/ApolloClient';
+import { DefaultOptions } from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 
 import { ApolloProvider } from './index';

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -411,7 +411,6 @@ describe('Query component', () => {
     });
 
     it('stopPolling', done => {
-      jest.useFakeTimers();
       expect.assertions(3);
 
       const data1 = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
@@ -434,7 +433,7 @@ describe('Query component', () => {
       ];
 
       const POLL_COUNT = 2;
-      const POLL_INTERVAL = 30;
+      const POLL_INTERVAL = 5;
       let count = 0;
 
       const Component = () => (
@@ -448,6 +447,10 @@ describe('Query component', () => {
             } else if (count === 1) {
               expect(stripSymbols(result.data)).toEqual(data2);
               result.stopPolling();
+              setTimeout(() => {
+                expect(count).toBe(POLL_COUNT);
+                done();
+              }, 10);
             }
             count++;
             return null;
@@ -460,13 +463,6 @@ describe('Query component', () => {
           <Component />
         </MockedProvider>,
       );
-
-      jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
-
-      catchAsyncError(done, () => {
-        expect(count).toBe(POLL_COUNT);
-        done();
-      });
     });
 
     it('updateQuery', done => {
@@ -624,7 +620,6 @@ describe('Query component', () => {
     });
 
     it('pollInterval', done => {
-      jest.useFakeTimers();
       expect.assertions(4);
 
       const data1 = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
@@ -662,6 +657,9 @@ describe('Query component', () => {
               expect(stripSymbols(result.data)).toEqual(data2);
             } else if (count === 2) {
               expect(stripSymbols(result.data)).toEqual(data3);
+            } else {
+              expect(count).toBe(POLL_COUNT);
+              done();
             }
             count++;
             return null;
@@ -674,13 +672,6 @@ describe('Query component', () => {
           <Component />
         </MockedProvider>,
       );
-
-      jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
-
-      catchAsyncError(done, () => {
-        expect(count).toBe(POLL_COUNT);
-        done();
-      });
     });
 
     it('skip', done => {

--- a/test/client/Query.test.tsx
+++ b/test/client/Query.test.tsx
@@ -348,8 +348,7 @@ describe('Query component', () => {
     });
 
     it('startPolling', done => {
-      jest.useFakeTimers();
-      expect.assertions(4);
+      expect.assertions(3);
 
       const data1 = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
       const data2 = { allPeople: { people: [{ name: 'Han Solo' }] } };
@@ -373,8 +372,7 @@ describe('Query component', () => {
       let count = 0;
       let isPolling = false;
 
-      const POLL_INTERVAL = 30;
-      const POLL_COUNT = 3;
+      const POLL_INTERVAL = 5;
 
       const Component = () => (
         <Query query={allPeopleQuery}>
@@ -386,6 +384,7 @@ describe('Query component', () => {
               isPolling = true;
               result.startPolling(POLL_INTERVAL);
             }
+
             catchAsyncError(done, () => {
               if (count === 0) {
                 expect(stripSymbols(result.data)).toEqual(data1);
@@ -393,6 +392,8 @@ describe('Query component', () => {
                 expect(stripSymbols(result.data)).toEqual(data2);
               } else if (count === 2) {
                 expect(stripSymbols(result.data)).toEqual(data3);
+              } else if (count === 3) {
+                done();
               }
             });
 
@@ -407,13 +408,6 @@ describe('Query component', () => {
           <Component />
         </MockedProvider>,
       );
-
-      jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
-
-      catchAsyncError(done, () => {
-        expect(count).toBe(POLL_COUNT);
-        done();
-      });
     });
 
     it('stopPolling', done => {

--- a/test/client/graphql/queries/index.test.tsx
+++ b/test/client/graphql/queries/index.test.tsx
@@ -484,56 +484,6 @@ describe('queries', () => {
     expect(errorCaught).toBeNull();
   });
 
-  // note this should log an error in the console until they are all cleaned up with react 16
-  it("errors if the passed props don't contain the needed variables", done => {
-    const query: DocumentNode = gql`
-      query people($first: Int!) {
-        allPeople(first: $first) {
-          people {
-            name
-          }
-        }
-      }
-    `;
-    const data = { allPeople: { people: [{ name: 'Luke Skywalker' }] } };
-    type Data = typeof data;
-
-    const variables = { first: 1 };
-    type Vars = typeof variables;
-
-    const link = mockSingleLink({
-      request: { query, variables },
-      result: { data },
-    });
-    const client = new ApolloClient({
-      link,
-      cache: new Cache({ addTypename: false }),
-    });
-
-    interface WrongProps {
-      frst: number;
-    }
-    const Container = graphql<WrongProps, Data, Vars>(query)(() => null);
-    class ErrorBoundary extends React.Component {
-      componentDidCatch(e: Error) {
-        expect(e.name).toMatch(/Invariant Violation/);
-        expect(e.message).toMatch(/The operation 'people'/);
-        done();
-      }
-
-      render() {
-        return this.props.children;
-      }
-    }
-    renderer.create(
-      <ApolloProvider client={client}>
-        <ErrorBoundary>
-          <Container frst={1} />
-        </ErrorBoundary>
-      </ApolloProvider>,
-    );
-  });
-
   // context
   it('allows context through updates', done => {
     const query: DocumentNode = gql`

--- a/test/client/graphql/queries/lifecycle.test.tsx
+++ b/test/client/graphql/queries/lifecycle.test.tsx
@@ -442,42 +442,31 @@ describe('[queries] lifecycle', () => {
       }
     `;
     const link1 = mockSingleLink(
+      // Data for "Load 1" below
       {
         request: { query },
         result: { data: { a: 1, b: 2, c: 3 } },
       },
-      {
-        request: { query },
-        result: { data: { a: 1, b: 2, c: 3 } },
-      },
+      // Data for "Load 2" below
       {
         request: { query },
         result: { data: { a: 1, b: 2, c: 3 } },
       },
     );
     const link2 = mockSingleLink(
+      // Data for "Load 3" below
       {
         request: { query },
         result: { data: { a: 4, b: 5, c: 6 } },
       },
-      {
-        request: { query },
-        result: { data: { a: 4, b: 5, c: 6 } },
-      },
+      // Data for "Load 4" below
       {
         request: { query },
         result: { data: { a: 4, b: 5, c: 6 } },
       },
     );
     const link3 = mockSingleLink(
-      {
-        request: { query },
-        result: { data: { a: 7, b: 8, c: 9 } },
-      },
-      {
-        request: { query },
-        result: { data: { a: 7, b: 8, c: 9 } },
-      },
+      // Data for "Load 5" below
       {
         request: { query },
         result: { data: { a: 7, b: 8, c: 9 } },
@@ -543,15 +532,26 @@ describe('[queries] lifecycle', () => {
 
     renderer.create(<ClientSwitcher />);
 
+    // Load 1
     await wait(1);
+
+    // Load 2
     refetchQuery!();
     await wait(1);
+
+    // Load 3
     switchClient!(client2);
     await wait(1);
+
+    // Load 4
     refetchQuery!();
     await wait(1);
+
+    // Load 5
     switchClient!(client3);
     await wait(1);
+
+    // Load 6
     switchClient!(client1);
     await wait(1);
     switchClient!(client2);
@@ -560,18 +560,41 @@ describe('[queries] lifecycle', () => {
     await wait(1);
 
     expect(renders).toEqual([
-      { loading: true },
+      // Load 1
+      { loading: true, a: undefined, b: undefined, c: undefined },
       { loading: false, a: 1, b: 2, c: 3 },
+
+      // Load 2
       { loading: true, a: 1, b: 2, c: 3 },
       { loading: false, a: 1, b: 2, c: 3 },
-      { loading: true },
+
+      // Load 3
+      { loading: true,a: undefined, b: undefined, c: undefined },
       { loading: false, a: 4, b: 5, c: 6 },
+
+      // Load 4
       { loading: true, a: 4, b: 5, c: 6 },
       { loading: false, a: 4, b: 5, c: 6 },
-      { loading: true },
+
+      // Load 5
+      { loading: true, a: undefined, b: undefined, c: undefined },
       { loading: false, a: 7, b: 8, c: 9 },
+
+      // Load 6
+
+      // The first render is caused by the component having its state updated
+      // when switching the client. The 2nd and 3rd renders are caused by the
+      // component re-subscribing to get data from Apollo Client.
       { loading: false, a: 1, b: 2, c: 3 },
+      { loading: false, a: 1, b: 2, c: 3 },
+      { loading: false, a: 1, b: 2, c: 3 },
+
       { loading: false, a: 4, b: 5, c: 6 },
+      { loading: false, a: 4, b: 5, c: 6 },
+      { loading: false, a: 4, b: 5, c: 6 },
+
+      { loading: false, a: 7, b: 8, c: 9 },
+      { loading: false, a: 7, b: 8, c: 9 },
       { loading: false, a: 7, b: 8, c: 9 },
     ]);
   });

--- a/test/client/graphql/queries/polling.test.tsx
+++ b/test/client/graphql/queries/polling.test.tsx
@@ -19,9 +19,9 @@ describe('[queries] polling', () => {
   });
   // polling
   it('allows a polling query to be created', done => {
-    jest.useFakeTimers();
+    expect.assertions(4);
 
-    const POLL_INTERVAL = 250;
+    const POLL_INTERVAL = 5;
     const POLL_COUNT = 4;
     const query: DocumentNode = gql`
       query people {
@@ -52,6 +52,10 @@ describe('[queries] polling', () => {
       }),
     })(() => {
       count++;
+      expect(true).toBe(true);
+      if (count === 4) {
+        done();
+      }
       return null;
     });
 
@@ -60,17 +64,6 @@ describe('[queries] polling', () => {
         <Container />
       </ApolloProvider>,
     );
-
-    jest.runTimersToTime(POLL_INTERVAL * POLL_COUNT);
-
-    try {
-      expect(count).toEqual(POLL_COUNT);
-      done();
-    } catch (e) {
-      done.fail(e);
-    } finally {
-      (wrapper as any).unmount();
-    }
   });
 
   it('exposes stopPolling as part of the props api', done => {


### PR DESCRIPTION
This PR makes a few odds/ends changes to React Apollo, to better align it with the upcoming Apollo Client 2.5.0 release and local state. It includes:

- Updating the `apollo-*` deps to use the `beta` versions from Apollo Client (for `react-apollo@beta` testing)
- Updates to the Apollo Link dependency and associated Typescript changes
- Disabling HOC prop variable validation, since it won't work with `@client @export` (see the description in https://github.com/apollographql/react-apollo/commit/cce3316e7e3ed65f554346fe59d6c320d6b695da for more details)
- Prevent React Apollo's `MockedProvider` from using `@client` fields in mocked out links, since `@client` fields are now local (and shouldn't be included in links).
- Start tracking the full last received query result in the `Query` component, so it can be used to help decide when a new render should be prevented (if the incoming result hasn't changed).

Please note that this PR is currently a work in progress, as there are a handful of test failures that need to be worked through. These failures aren't related to React Apollo changes, but are related to updating to `apollo-*` `beta` deps. 