### PR TITLE
Allow `MockedResponse` results to be returned from a function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@
 
 ### Improvements
 
+- A function can now be set as a `MockedResponse` `result` when using
+  `MockedProvider`, such that every time the mocked result is returned,
+  the function is run to calculate the result. This opens up new testing
+  possibilities, like being able to verify if a mocked result was actually
+  requested and received by a test.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#2788](https://github.com/apollographql/react-apollo/pull/2788)
+
 ## 2.4.1
 
 ### Improvements

--- a/src/test-links.ts
+++ b/src/test-links.ts
@@ -95,7 +95,7 @@ export class MockLink extends ApolloLink {
         } else {
           if (result) {
             observer.next(
-              Object.prototype.toString.call(result) === '[object Function]'
+              typeof result === 'function'
                 ? (result as ResultFunction<FetchResult>)()
                 : result
             );

--- a/src/test-links.ts
+++ b/src/test-links.ts
@@ -11,12 +11,14 @@ import { print } from 'graphql/language/printer';
 import { addTypenameToDocument } from 'apollo-utilities';
 const isEqual = require('lodash.isequal');
 
+type ResultFunction<T> = () => T;
+
 export interface MockedResponse {
   request: GraphQLRequest;
-  result?: FetchResult;
+  result?: FetchResult | ResultFunction<FetchResult>;
   error?: Error;
   delay?: number;
-  newData?: () => FetchResult;
+  newData?: ResultFunction<FetchResult>;
 }
 
 export interface MockedSubscriptionResult {
@@ -86,12 +88,18 @@ export class MockLink extends ApolloLink {
       throw new Error(`Mocked response should contain either result or error: ${key}`);
     }
 
-    return new Observable<FetchResult>(observer => {
+    return new Observable(observer => {
       let timer = setTimeout(() => {
         if (error) {
           observer.error(error);
         } else {
-          if (result) observer.next(result);
+          if (result) {
+            observer.next(
+              Object.prototype.toString.call(result) === '[object Function]'
+                ? (result as ResultFunction<FetchResult>)()
+                : result
+            );
+          }
           observer.complete();
         }
       }, delay ? delay : 0);


### PR DESCRIPTION
The `result` property of a `MockedResponse` is currently restricted to being a pre-configured fixed value. Allowing results to be calculated/returned from a function instead of being pre-configured, opens up new test verification paths, that can be useful when using `MockedProvider`.

This PR adjusts `MockedResponse`’s `result` such that if a function is set for its value, that function will be fired and its result will be passed to the Observable matching the incoming mocked `request`.

Fixes https://github.com/apollographql/apollo-feature-requests/issues/84.