### PR TITLE
Allow resolvers to be passed into `MockedProvider` and set a default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 2.5.1
+
+### Bug Fixes
+
+- Make sure `MockedProvider` enables Apollo Client 2.5's local state handling,
+  and allow custom / mocked resolvers to be passed in as props, and used with
+  the created test `ApolloClient` instance.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#2825](https://github.com/apollographql/react-apollo/pull/2825)
+
+
 ## 2.5.0
 
 ### Improvements

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ApolloClient from 'apollo-client';
-import { DefaultOptions } from 'apollo-client';
+import { DefaultOptions, Resolvers } from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 
 import { ApolloProvider } from './index';
@@ -13,6 +13,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   addTypename?: boolean;
   defaultOptions?: DefaultOptions;
   cache?: ApolloCache<TSerializedCache>;
+  resolvers?: Resolvers;
 }
 
 export interface MockedProviderState {
@@ -27,11 +28,18 @@ export class MockedProvider extends React.Component<MockedProviderProps, MockedP
   constructor(props: MockedProviderProps) {
     super(props);
 
-    const { mocks, addTypename, defaultOptions, cache } = this.props;
+    const {
+      mocks,
+      addTypename,
+      defaultOptions,
+      cache,
+      resolvers = {},
+    } = this.props;
     const client = new ApolloClient({
       cache: cache || new Cache({ addTypename }),
       defaultOptions,
       link: new MockLink(mocks || [], addTypename),
+      resolvers,
     });
 
     this.state = { client };


### PR DESCRIPTION
After the changes in https://github.com/apollographql/apollo-client/pull/4499, when `MockedProvider` is currently used it doesn't have any `resolvers` set. This means `@client` directives are passed into the link chain. Since we don't currently allow people to modify the link chain that `MockedProvider` uses, it's safe to assume people won't want this behaviour, as they can't test things like `apollo-link-state` this way. This PR sets a default `resolvers` value of `{}` to enable AC 2.5's new local state handling, and opens the door for passing custom resolvers into the `MockedProvider` via props.

Helps with https://github.com/apollographql/fullstack-tutorial/pull/73.