### PR TITLE
Export Context type from types.ts instead of walkTree.ts.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Change log
 
+## vNEXT
+
+### Bug Fixes
+
+- Export `Context` type from `types.ts` instead of `walkTree.ts`,
+  to reenable `import { Context } from 'react-apollo'` (which has been
+  broken since 2.4.0). <br/>
+  [@benjamn](https://github.com/benjamn) in [#2825](https://github.com/apollographql/react-apollo/pull/2832)
+
 ## 2.5.1
 
 ### Bug Fixes
@@ -8,7 +17,6 @@
   and allow custom / mocked resolvers to be passed in as props, and used with
   the created test `ApolloClient` instance.  <br/>
   [@hwillson](https://github.com/hwillson) in [#2825](https://github.com/apollographql/react-apollo/pull/2825)
-
 
 ## 2.5.0
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ import ApolloClient, {
 } from 'apollo-client';
 import { MutationFn } from './Mutation';
 
+export interface Context {
+  [key: string]: any;
+};
+
 export type OperationVariables = {
   [key: string]: any;
 };
@@ -31,7 +35,7 @@ export interface MutationOpts<TData = any, TGraphQLVariables = OperationVariable
   update?: MutationUpdaterFn<TData>;
   client?: ApolloClient<any>;
   notifyOnNetworkStatusChange?: boolean;
-  context?: Record<string, any>;
+  context?: Context;
   onCompleted?: (data: TData) => void;
   onError?: (error: ApolloError) => void;
   fetchPolicy?: FetchPolicy;
@@ -45,7 +49,7 @@ export interface QueryOpts<TGraphQLVariables = OperationVariables> {
   pollInterval?: number;
   client?: ApolloClient<any>;
   notifyOnNetworkStatusChange?: boolean;
-  context?: Record<string, any>;
+  context?: Context;
   partialRefetch?: boolean;
 }
 

--- a/src/walkTree.ts
+++ b/src/walkTree.ts
@@ -1,8 +1,5 @@
 import * as React from 'react';
-
-export interface Context {
-  [key: string]: any;
-}
+import { Context } from './types';
 
 interface PreactElement<P> {
   attributes: P;


### PR DESCRIPTION
When we stopped reexporting everything from `walkTree.ts` as part of #2533, we also stopped exporting the `Context` type that it uses.

Moving the declaration and export of `Context` from `walkTree.ts` to `types.ts` restores the ability to do
```ts
import { Context } from "react-apollo"
```
which should fix #2824.