### PR TITLE
Update lastResult whenever data changes to ensure components re-rende…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@
   component, after an error was received, variables were adjusted, and then
   the good data was fetched.  <br/>
   [@MerzDaniel](https://github.com/MerzDaniel) in [#2718](https://github.com/apollographql/react-apollo/pull/2718)
+- Fixed an issue that prevented `Query` component updates from firing (under
+  certain circumstances) due to the internal `lastResult` value (that's used
+  to help prevent unnecessary re-renders) not being updated.  <br/>
+  [@Glennrs](https://github.com/Glennrs) in [#2840](https://github.com/apollographql/react-apollo/pull/2840)
 
 ### Improvements
 

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -369,6 +369,9 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
         }
 
         initial = undefined;
+        if (this.lastResult) {
+          this.lastResult = this.queryObservable!.getLastResult();
+        }
         this.updateCurrentData();
       },
       error: error => {


### PR DESCRIPTION
I've been unable to write a test case to reproduce this scenario, however, the logic is fairly simple to follow. I'm happy to be informed if I'm missing something and this PR is not required. Scenario is:

1) Component renders with value from cache, which sets lastResult.
2) Value of cache is set to another value. Component re-renders.
3) Value is set back to the original value, therefore shallowEquals does not pass since lastResult is fixed to the original render.

This PR ensures that lastResult is updated if set, when new data is available.

Fixes https://github.com/apollographql/react-apollo/issues/2857.
Fixes https://github.com/apollographql/react-apollo/issues/2887.