### PR TITLE
Bundle reductions inspired by examples/rollup app.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "bundlesize": [
     {
       "path": "./dist/bundlesize.js",
-      "maxSize": "6.4 KB"
+      "maxSize": "5.2 KB"
     }
   ],
   "jest": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,19 @@ function onwarn(message) {
   }
 }
 
+const globals = {
+  'apollo-client': 'apollo.core',
+  'hoist-non-react-statics': 'hoistNonReactStatics',
+  'prop-types': 'propTypes',
+  'react': 'react',
+  'ts-invariant': 'invariant',
+  'tslib': 'tslib',
+};
+
+function external(id) {
+  return Object.prototype.hasOwnProperty.call(globals, id);
+}
+
 export default [
   {
     input: 'src/index.ts',
@@ -20,12 +33,11 @@ export default [
       file: 'lib/react-apollo.esm.js',
       format: 'esm',
       sourcemap: true,
+      globals,
     },
+    external,
     plugins: [
-      node({
-        module: true,
-        only: ['tslib']
-      }),
+      node({ module: true }),
       typescriptPlugin({ typescript }),
       invariantPlugin(),
       filesize(),
@@ -37,8 +49,10 @@ export default [
     output: {
       file: 'lib/react-apollo.cjs.js',
       format: 'cjs',
-      name: 'react-apollo'
+      name: 'react-apollo',
+      globals,
     },
+    external,
     onwarn,
   },
   {
@@ -46,8 +60,10 @@ export default [
     output: {
       file: 'lib/react-apollo.umd.js',
       format: 'umd',
-      name: 'react-apollo'
+      name: 'react-apollo',
+      globals,
     },
+    external,
     onwarn,
   },
   {
@@ -55,8 +71,10 @@ export default [
     output: {
       file: 'dist/bundlesize.js',
       format: 'cjs',
-      name: 'react-apollo'
+      name: 'react-apollo',
+      globals,
     },
+    external,
     plugins: [
       uglify({
         mangle: {


### PR DESCRIPTION
Part of our ongoing effort to rein in bundle sizes: https://github.com/apollographql/react-apollo/issues/2743

Although the `bundlesize` check will show a reduction in the size of `react-apollo` itself, the most accurate measurement of these improvements is [the `examples/rollup` app](https://github.com/apollographql/react-apollo/tree/master/examples/rollup), introduced by #2839.

That said, the numbers are pretty close, because the `tslib` package is now shared by so many Apollo packages that it's effectively free from the perspective of any single package.