### PR TITLE
Disable queryDeduplication in some flaky tests.

### DIFF
--- a/test/client/graphql/queries/loading.test.tsx
+++ b/test/client/graphql/queries/loading.test.tsx
@@ -309,6 +309,7 @@ describe('[queries] loading', () => {
     const client = new ApolloClient({
       link,
       cache: new Cache({ addTypename: false }),
+      queryDeduplication: false,
     });
     let wrapper: ReactWrapper<any>,
       app: React.ReactElement<any>,

--- a/test/client/graphql/queries/skip.test.tsx
+++ b/test/client/graphql/queries/skip.test.tsx
@@ -568,6 +568,7 @@ describe('[queries] skip', () => {
     const client = new ApolloClient({
       link,
       cache: new Cache({ addTypename: false }),
+      queryDeduplication: false,
     });
 
     let hasSkipped = false;


### PR DESCRIPTION
This PR is preparation for https://github.com/apollographql/apollo-client/pull/4576, which introduces some slight changes in the timing of link requests, resulting in query deduplication in some new (or just more frequent) cases.

While deduplication should be harmless/beneficial in most real applications, it can affect the number of requests made to the underlying `ApolloLink` in ways that some `react-apollo` tests do not expect. To make those tests more reliable, it seems best to disable query deduplication by passing `queryDeduplication: false` to the `ApolloClient` constructor used by the test.

I would be more worried about this change if the tests were reliably failing, but the `loading.test.tsx` test was passing occasionally without this change, and the rate of success could be increased by such changes as adding `console.log` statements. In other words, I'm fairly certain these tests were never adequately defending against the possibility of deduplication.