### PR TITLE
Force `test-utils` to use the CJS version of React Apollo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Change log
 
+## vNext
+
+### Bug Fixes
+
+- Fixes `Could not find "client" in the context of ApolloConsumer` errors when
+  using `MockedProvider`.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#2907](https://github.com/apollographql/react-apollo/pull/2907)
+
+
 ## 2.5.3
 
 ### Bug Fixes

--- a/src/ApolloContext.ts
+++ b/src/ApolloContext.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ApolloClient from 'apollo-client';
 import { DocumentNode } from 'graphql';
 

--- a/src/react-apollo.cjs.ts
+++ b/src/react-apollo.cjs.ts
@@ -1,0 +1,10 @@
+// This file is a temporary hack used by `test-utils` to make sure
+// the CJS bundled version of the codebase (via `lib/react-apollo.cjs.js`) is
+// used when running tests.
+//
+// See: https://github.com/apollographql/react-apollo/pull/2907
+//
+// This hack is temporary as the `test-utils` will be moved into their own
+// repo in React Apollo 3.0.
+
+export * from './index';

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -3,7 +3,7 @@ import ApolloClient from 'apollo-client';
 import { DefaultOptions, Resolvers } from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 
-import { ApolloProvider } from './index';
+import { ApolloProvider } from './react-apollo.cjs';
 import { MockedResponse, MockLink } from './test-links';
 import { ApolloCache } from 'apollo-cache';
 export * from './test-links';


### PR DESCRIPTION
When running `MockedProvider` tests from a CLI or CI, those tests are run using the CommonJS bundled version of React Apollo (`react-apollo.cjs.js`). The `test-utils` themselves however, like `MockedProvider`, are not included in the production `react-apollo.cjs.js` bundle, to help keep the prod bundle size down. To use `MockedProvider`, it must be accessed using a nested/direct import like:

```js
import { MockedProvider } from "react-apollo/test-utils";
```

Unfortunately, this nested import means `MockedProvider` is loaded outside of the `react-apollo.cjs.js` bundle, which means it requires and uses its own versions of other supporting React Apollo files. This causes problems in areas like using React's Context API. Both `MockedProvider` and the component's it's attempting to test create and use their own versions of shared Context, which are not available to each other. So when `MockedProvider` creates a new Context and adds the `client` instance to it, its child components don't have access to it, since they've created their own Context separately.

In React Apollo 3.0 we're going to move the `test-utils` out into their own package, which will fix this problem. As a workaround for now, this PR forces the `test-utils` to use the `react-apollo.cjs.js` version of React Apollo. This means tests have access to the same dependencies as the components being tested.

Fixes https://github.com/apollographql/react-apollo/issues/2900.