### PR TITLE
Persist `no-cache` Query loaded data when re-rendering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 - Fixes `Could not find "client" in the context of ApolloConsumer` errors when
   using `MockedProvider`.  <br/>
   [@hwillson](https://github.com/hwillson) in [#2907](https://github.com/apollographql/react-apollo/pull/2907)
+- Ensure `Query` components using a `fetchPolicy` of `no-cache` have their
+  data preserved when the components tree is re-rendered.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#TODO](https://github.com/apollographql/react-apollo/pull/TODO)
 
 
 ## 2.5.3

--- a/src/Query.tsx
+++ b/src/Query.tsx
@@ -434,6 +434,7 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
         error = new ApolloError({ graphQLErrors: errors });
       }
 
+      const { fetchPolicy } = this.queryObservable!.options;
       Object.assign(data, { loading, networkStatus, error });
 
       if (loading) {
@@ -442,8 +443,14 @@ export default class Query<TData = any, TVariables = OperationVariables> extends
         Object.assign(data, {
           data: (this.queryObservable!.getLastResult() || {}).data,
         });
+      } else if (
+        fetchPolicy === 'no-cache' &&
+        Object.keys(currentResult.data).length === 0
+      ) {
+        // Make sure data pulled in by a `no-cache` query is preserved
+        // when the components parent tree is re-rendered.
+        data.data = this.previousData;
       } else {
-        const { fetchPolicy } = this.queryObservable!.options;
         const { partialRefetch } = this.props;
         if (
           partialRefetch &&


### PR DESCRIPTION
This PR makes sure `no-cache` (`fetchPolicy`) loaded data is preserved when a components tree is re-rendered.

Fixes #2870.