### PR TITLE
Fix types to pass own props through hoc

### DIFF
--- a/src/mutation-hoc.tsx
+++ b/src/mutation-hoc.tsx
@@ -30,11 +30,11 @@ export function withMutation<
   let mapPropsToOptions = options as (props: any) => MutationOpts;
   if (typeof mapPropsToOptions !== 'function') mapPropsToOptions = () => options as MutationOpts;
 
-  return (
-    WrappedComponent: React.ComponentType<TProps & TChildProps>,
-  ): React.ComponentClass<TProps> => {
+  return <OwnProps extends {}>(
+    WrappedComponent: React.ComponentType<OwnProps & TProps & TChildProps>,
+  ): React.ComponentClass<OwnProps & TProps> => {
     const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
-    class GraphQL extends GraphQLBase<TProps, TChildProps> {
+    class GraphQL extends GraphQLBase<OwnProps & TProps, TChildProps> {
       static displayName = graphQLDisplayName;
       static WrappedComponent = WrappedComponent;
       render() {
@@ -69,7 +69,7 @@ export function withMutation<
 
               return (
                 <WrappedComponent
-                  {...props as TProps}
+                  {...props as OwnProps & TProps}
                   {...childProps as any}
                 />
               );

--- a/src/query-hoc.tsx
+++ b/src/query-hoc.tsx
@@ -43,11 +43,11 @@ export function withQuery<
 
   // allow for advanced referential equality checks
   let lastResultProps: TChildProps | void;
-  return (
-    WrappedComponent: React.ComponentType<TProps & TChildProps>,
-  ): React.ComponentClass<TProps> => {
+  return <OwnProps extends {}>(
+    WrappedComponent: React.ComponentType<OwnProps & TProps & TChildProps>,
+  ): React.ComponentClass<OwnProps & TProps> => {
     const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
-    class GraphQL extends GraphQLBase<TProps, TChildProps> {
+    class GraphQL extends GraphQLBase<OwnProps & TProps, TChildProps> {
       static displayName = graphQLDisplayName;
       static WrappedComponent = WrappedComponent;
 
@@ -81,7 +81,7 @@ export function withQuery<
               if (shouldSkip) {
                 return (
                   <WrappedComponent
-                    {...props as TProps}
+                    {...props as OwnProps & TProps}
                     {...{} as TChildProps}
                   />
                 );
@@ -96,7 +96,7 @@ export function withQuery<
               if (operationOptions.props) {
                 const newResult: OptionProps<TProps, TData, TGraphQLVariables> = {
                   [name]: result,
-                  ownProps: props as TProps,
+                  ownProps: props as OwnProps & TProps,
                 };
                 lastResultProps = operationOptions.props(newResult, lastResultProps);
                 childProps = lastResultProps;
@@ -104,7 +104,7 @@ export function withQuery<
 
               return (
                 <WrappedComponent
-                  {...props as TProps}
+                  {...props as OwnProps & TProps}
                   {...childProps as TChildProps}
                 />
               );

--- a/src/subscription-hoc.tsx
+++ b/src/subscription-hoc.tsx
@@ -40,14 +40,14 @@ export function withSubscription<
 
   // allow for advanced referential equality checks
   let lastResultProps: TChildProps | void;
-  return (
-    WrappedComponent: React.ComponentType<TProps & TChildProps>,
-  ): React.ComponentClass<TProps> => {
+  return <OwnProps extends {}>(
+    WrappedComponent: React.ComponentType<OwnProps & TProps & TChildProps>,
+  ): React.ComponentClass<OwnProps & TProps> => {
     const graphQLDisplayName = `${alias}(${getDisplayName(WrappedComponent)})`;
-    class GraphQL extends GraphQLBase<TProps, TChildProps, { resubscribe: boolean }> {
+    class GraphQL extends GraphQLBase<OwnProps & TProps, TChildProps, { resubscribe: boolean }> {
       static displayName = graphQLDisplayName;
       static WrappedComponent = WrappedComponent;
-      constructor(props: TProps) {
+      constructor(props: OwnProps & TProps) {
         super(props);
         this.state = { resubscribe: false };
       }
@@ -88,7 +88,7 @@ export function withSubscription<
               if (shouldSkip) {
                 return (
                   <WrappedComponent
-                    {...props as TProps}
+                    {...props as OwnProps & TProps}
                     {...{} as TChildProps}
                   />
                 );
@@ -103,7 +103,7 @@ export function withSubscription<
               if (operationOptions.props) {
                 const newResult: OptionProps<TProps, TData, TGraphQLVariables> = {
                   [name]: result,
-                  ownProps: props as TProps,
+                  ownProps: props as OwnProps & TProps,
                 };
                 lastResultProps = operationOptions.props(newResult, lastResultProps);
                 childProps = lastResultProps;
@@ -111,7 +111,7 @@ export function withSubscription<
 
               return (
                 <WrappedComponent
-                  {...props as TProps}
+                  {...props as OwnProps & TProps}
                   {...childProps as TChildProps}
                 />
               );


### PR DESCRIPTION
This PR extends types of HOCs to allow wrapped component's props to be used in parent component.

Following the [Using Apollo with TypeScript](https://www.apollographql.com/docs/react/recipes/static-typing) and source code, it seems I have to set `InputProps` explicitly and only these props I'm allowed to use in parent component. However, sometimes there're props passed down to wrapped component, which aren't related to graphql HOC at all.

Possibly related issues: https://github.com/apollographql/react-apollo/issues/2801 https://github.com/apollographql/react-apollo/issues/2083

---

I have a [query](https://github.com/tricoder42/apollo-typings-fix/blob/master/query.ts) as HOC where I transform received data in `options.props`:

```ts
interface ResponseType {
  remoteValue: number
}

export interface withDataProps {
  loading: boolean
  remoteValue: number | undefined
}

export const withData = graphql<{}, ResponseType, {}, withDataProps>(
  gql`
    query getRemoteValue {
      remoteValue
    }
  `,
  {
    props: ({ data }) =>
      data == null
        ? { loading: false, remoteValue: undefined }
        : {
            loading: data.loading,
            remoteValue: data.remoteValue
          }
  }
)
```

I use this HOC to provide data to a [component](https://github.com/tricoder42/apollo-typings-fix/blob/master/DataComponent.tsx):

```ts
type DataComponentProps = {
  // own props, not provided by HOC
  value: number
} & withDataProps

export const DataComponent = withData(
  ({ remoteValue, value }: DataComponentProps) => (
    <div>
      Value: {value}, Remote Value: {remoteValue}
    </div>
  )
)
```

**Intended outcome**

I should be able to set `DataComponent` props, which are not provided by HOC:

```ts
<DataComponent value={42} />
```

**Actual outcome**

Typescript complains that `value` props doesn't exist on `DataComponent`:

```
test.tsx:8:8 - error TS2322: Type '{ value: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<{}, any, any>> & Re
adonly<{}> & Readonly<{ children?: ReactNode; }>'.
  Property 'value' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<{}, any, any>> & Readonly<{}> & Readonly<{ children?: Reac
tNode; }>'.

8       <DataComponent value={42} />
```

**How to reproduce the issue**

1. Checkout https://github.com/tricoder42/apollo-typings-fix
2. Run `yarn; yarn tsc`