### PR TITLE
useQueryLoader() hook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "prettier.singleQuote": true
+  "prettier.singleQuote": true,
+  "prettier.semi": true
 }

--- a/examples/hooks/client/src/RocketDetail.tsx
+++ b/examples/hooks/client/src/RocketDetail.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useQueryLoader } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+
+import { RocketInventory } from './types';
+
+const GET_ROCKET_DETAILS = gql`
+  query getRocket($id: ID!) {
+    rocket(id: $id) {
+      id
+      model
+      year
+      stock
+    }
+  }
+`;
+
+export interface RocketDetailProps {
+  rocketId: number;
+}
+
+export function RocketDetail({ rocketId }: RocketDetailProps) {
+  return useQueryLoader(GET_ROCKET_DETAILS, {
+    variables: { id: rocketId }
+  })(({ data: { rocket } }: { data: { rocket: RocketInventory } }) => {
+    if (!rocket) {
+      return <div>Rocket ID {rocketId} not found</div>;
+    }
+    return (
+      <article>
+        <h2>Rocket Details</h2>
+        <dl>
+          <dt>Model</dt>
+          <dd>{rocket.model}</dd>
+          <dt>Year</dt>
+          <dd>{rocket.year}</dd>
+          <dt>Stock</dt>
+          <dd>{rocket.stock}</dd>
+        </dl>
+      </article>
+    );
+  });
+}

--- a/examples/hooks/client/src/index.tsx
+++ b/examples/hooks/client/src/index.tsx
@@ -12,6 +12,7 @@ import { OperationDefinitionNode } from 'graphql';
 
 import { LatestNews } from './LatestNews';
 import { RocketInventoryList } from './RocketInventoryList';
+import { RocketDetail } from './RocketDetail';
 import { NewRocketForm } from './NewRocketForm';
 
 const httpLink = new HttpLink({
@@ -60,13 +61,32 @@ function App() {
       </Row>
       <LatestNews />
       <RocketInventoryList />
+      <RocketDetail rocketId={1} />
       <NewRocketForm />
     </Container>
   );
 }
 
+// These components are used by the useQueryLoader() hook
+function Loader() {
+  return <div>Loading...</div>;
+}
+function ErrorMessage({ errorObject }: { errorObject: Error }) {
+  const isProd = process.env.NODE_ENV === 'production';
+  const message = isProd ? 'An internal error occurred' : errorObject.message;
+  if (!isProd) {
+    console.log('Apollo GraphQL error: ', errorObject);
+  }
+  return <div>{message}</div>;
+}
+
+const options = {
+  defaultLoadingComponent: Loader,
+  defaultErrorComponent: ErrorMessage
+};
+
 ReactDOM.render(
-  <ApolloProvider client={client}>
+  <ApolloProvider client={client} options={options}>
     <App />
   </ApolloProvider>,
   document.getElementById('root')

--- a/examples/hooks/server/index.js
+++ b/examples/hooks/server/index.js
@@ -24,6 +24,7 @@ const typeDefs = gql`
 
   type Query {
     rocketInventory: [RocketInventory]
+    rocket(id: ID!): RocketInventory
   }
 
   type Mutation {
@@ -70,6 +71,10 @@ const resolvers = {
   Query: {
     rocketInventory() {
       return rocketInventoryData;
+    },
+    rocket(_, { id }) {
+      id = parseInt(id);
+      return rocketInventoryData.find(r => r.id === id);
     }
   },
 

--- a/packages/common/src/context/ApolloContext.ts
+++ b/packages/common/src/context/ApolloContext.ts
@@ -4,6 +4,12 @@ import ApolloClient from 'apollo-client';
 export interface ApolloContextValue {
   client?: ApolloClient<object>;
   renderPromises?: Record<any, any>;
+  options?: ApolloContextOptions;
+}
+
+export interface ApolloContextOptions {
+  defaultLoadingComponent?: React.ComponentType<any>;
+  defaultErrorComponent?: React.ComponentType<{ errorObject: Error }>;
 }
 
 let apolloContext: React.Context<ApolloContextValue>;

--- a/packages/common/src/context/ApolloProvider.tsx
+++ b/packages/common/src/context/ApolloProvider.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import ApolloClient from 'apollo-client';
 import { invariant } from 'ts-invariant';
 
-import { getApolloContext } from './ApolloContext';
+import { getApolloContext, ApolloContextOptions } from './ApolloContext';
 
 export interface ApolloProviderProps<TCache> {
   client: ApolloClient<TCache>;
   children: React.ReactNode | React.ReactNode[] | null;
+  options?: ApolloContextOptions;
 }
 
 export const ApolloProvider: React.FC<ApolloProviderProps<any>> = ({
   client,
+  options,
   children
 }) => {
   const ApolloContext = getApolloContext();
@@ -19,6 +21,9 @@ export const ApolloProvider: React.FC<ApolloProviderProps<any>> = ({
       {(context = {}) => {
         if (client) {
           context.client = client;
+        }
+        if (options) {
+          context.options = options;
         }
 
         invariant(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 export {
   ApolloContextValue,
+  ApolloContextOptions,
   getApolloContext,
   resetApolloContext
 } from './context/ApolloContext';

--- a/packages/hooks/src/__tests__/useQueryLoader.test.tsx
+++ b/packages/hooks/src/__tests__/useQueryLoader.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { MockedProvider } from '@apollo/react-testing';
+import { render, cleanup } from 'react-testing-library';
+
+import { useQueryLoader } from '../useQueryLoader';
+
+describe('useQueryLoader Hook', () => {
+  afterEach(cleanup);
+
+  const Loader = () => <div>Loading...</div>;
+  const ErrorMessage = ({ errorObject }: { errorObject: Error }) => (
+    <div>{errorObject.message}</div>
+  );
+
+  const options = {
+    defaultLoadingComponent: Loader,
+    defaultErrorComponent: ErrorMessage
+  };
+
+  const query: DocumentNode = gql`
+    query {
+      cars {
+        make
+        model
+        vin
+      }
+    }
+  `;
+
+  it('should handle a simple query properly', done => {
+    const resultData = {
+      cars: [
+        {
+          make: 'Audi',
+          model: 'RS8',
+          vin: 'DOLLADOLLABILL',
+          __typename: 'Car'
+        }
+      ]
+    };
+
+    const mocks = [
+      {
+        request: {
+          query
+        },
+        result: { data: resultData }
+      }
+    ];
+
+    const Component = () =>
+      useQueryLoader(query)(({ data }) => {
+        expect(data).toEqual(resultData);
+        done();
+        return null;
+      });
+
+    const { container } = render(
+      <MockedProvider mocks={mocks} contextOptions={options}>
+        <Component />
+      </MockedProvider>
+    );
+
+    expect(container.innerHTML).toEqual('<div>Loading...</div>');
+  });
+
+  it('should handle errors', done => {
+    const mockError = [
+      {
+        request: { query },
+        error: new Error('test error')
+      }
+    ];
+
+    const Component = () => useQueryLoader(query, { onError })(() => null);
+
+    const { container } = render(
+      <MockedProvider mocks={mockError} contextOptions={options}>
+        <Component />
+      </MockedProvider>
+    );
+
+    expect(container.innerHTML).toEqual('<div>Loading...</div>');
+
+    function onError(err: Error) {
+      expect(err.message).toContain('test error');
+      done();
+    }
+  });
+});

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from '@apollo/react-common';
 
 export { useQuery } from './useQuery';
+export { useQueryLoader } from './useQueryLoader';
 export { useMutation } from './useMutation';
 export { useSubscription } from './useSubscription';
 export { useApolloClient } from './useApolloClient';

--- a/packages/hooks/src/useQueryLoader.tsx
+++ b/packages/hooks/src/useQueryLoader.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { invariant } from 'ts-invariant';
+import {
+  getApolloContext,
+  OperationVariables,
+  QueryResult
+} from '@apollo/react-common';
+import { DocumentNode } from 'graphql';
+import { useQuery } from './useQuery';
+import { QueryHookOptions } from './types';
+
+export interface QueryLoaderResult<TData, TVariables>
+  extends Pick<
+    QueryResult<TData, TVariables>,
+    | 'startPolling'
+    | 'stopPolling'
+    | 'subscribeToMore'
+    | 'updateQuery'
+    | 'refetch'
+    | 'variables'
+    | 'fetchMore'
+    | 'client'
+    | 'networkStatus'
+  > {
+  data: TData;
+}
+
+function useApolloContextOptions() {
+  const { client, options = {} } = React.useContext(getApolloContext());
+  invariant(
+    client,
+    'No Apollo Client instance can be found. Please ensure that you ' +
+      'have called `ApolloProvider` higher up in your tree.'
+  );
+  invariant(
+    options.defaultLoadingComponent && options.defaultErrorComponent,
+    'The `defaultLoadingComponent` and `defaultErrorComponent` options must be set in order to use the `useQueryLoader` hook'
+  );
+  return options;
+}
+
+type RenderCallback<TData, TVariables> = (
+  result: QueryLoaderResult<TData, TVariables>
+) => React.ReactElement<any> | null;
+
+export function useQueryLoader<TData = any, TVariables = OperationVariables>(
+  query: DocumentNode,
+  options?: QueryHookOptions
+): (cb: RenderCallback<TData, TVariables>) => React.ReactElement<any> | null {
+  const result = useQuery(query, options);
+  return (renderCallback: RenderCallback<TData, TVariables>) =>
+    render({ result, renderCallback });
+}
+
+interface QueryLoaderProps {
+  result: QueryResult<any, any>;
+  renderCallback: RenderCallback<any, any>;
+}
+
+function render({ result, renderCallback }: QueryLoaderProps) {
+  const {
+    defaultLoadingComponent,
+    defaultErrorComponent
+  } = useApolloContextOptions();
+  if (!(defaultLoadingComponent && defaultErrorComponent)) {
+    throw Error(
+      'defaultLoadingComponent and defaultErrorComponent must be set prior to using the useQueryLoader() hook'
+    );
+  }
+  if (result.loading) {
+    return React.createElement(defaultLoadingComponent);
+  }
+  if (result.error) {
+    return React.createElement(defaultErrorComponent, {
+      errorObject: result.error
+    });
+  }
+  return renderCallback(result);
+}

--- a/packages/testing/src/mocks/MockedProvider.tsx
+++ b/packages/testing/src/mocks/MockedProvider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ApolloClient, DefaultOptions, Resolvers } from 'apollo-client';
 import { ApolloCache } from 'apollo-cache';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
-import { ApolloProvider } from '@apollo/react-common';
+import { ApolloProvider, ApolloContextOptions } from '@apollo/react-common';
 
 import { MockLink } from './mockLink';
 import { MockedResponse } from './types';
@@ -15,6 +15,7 @@ export interface MockedProviderProps<TSerializedCache = {}> {
   resolvers?: Resolvers;
   childProps?: object;
   children?: React.ReactElement;
+  contextOptions?: ApolloContextOptions;
 }
 
 export interface MockedProviderState {
@@ -44,9 +45,9 @@ export class MockedProvider extends React.Component<
   }
 
   public render() {
-    const { children, childProps } = this.props;
+    const { children, childProps, contextOptions } = this.props;
     return children ? (
-      <ApolloProvider client={this.state.client}>
+      <ApolloProvider client={this.state.client} options={contextOptions}>
         {React.cloneElement(React.Children.only(children), { ...childProps })}
       </ApolloProvider>
     ) : null;


### PR DESCRIPTION
For an overview of this PR and the motivation for it, see https://github.com/apollographql/apollo-feature-requests/issues/106.

I'm very open to feedback on this...all the tests and examples work, but there are multiple potential variations on the API.

I added a new component to the example app just for the sake of demonstrating usage of the hook, but of course `useQueryLoader()` doesn't necessarily need to be in the example app, or could be used in a different way. Happy to adjust or remove the example if needed.