### PR TITLE
New issue template changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,8 @@
+---
+name: 🐛 Reporting a Bug
+about: Open a new issue here if something isn't working as expected.
+---
+
 <!--
   Thanks for filing an issue on React Apollo!
 
@@ -5,7 +10,7 @@
 
   If you don't follow the template, your issue may end up being closed without anyone looking at it carefully, because it is not actionable for us without the information in this template.
 
-  If you're filing a feature request, you do not need to follow the outline below, but please include "feature idea" in the title and include a specific example in which that feature would be useful.
+  **PLEASE NOTE:** Feature requests and non-bug related discussions are no longer managed in this repo. Feature requests should be opened in https://github.com/apollographql/apollo-feature-requests.
 -->
 
 **Intended outcome:**
@@ -23,12 +28,15 @@ A description of what actually happened, including a screenshot or copy-paste of
 **How to reproduce the issue:**
 
 <!--
-If possible, please create a reproduction using https://github.com/apollographql/react-apollo-error-template and link to it here. If you prefer an in-browser way to create reproduction, try https://codesandbox.io/s/7361K9q6w
+If possible, please create a reproduction using https://github.com/apollographql/react-apollo-error-template and link to it here. If you prefer an in-browser way to create reproduction, try: https://codesandbox.io/s/apollo-client-error-template-7762p
 
 Instructions for how the issue can be reproduced by a maintainer or contributor. Be as specific as possible, and only mention what is necessary to reproduce the bug. If possible, try to isolate the exact circumstances in which the bug occurs and avoid speculation over what the cause might be.
 -->
 
 **Version**
 
-- apollo-client@<version number>
-- react-apollo@<version number>
+<!--
+Run the following command in your project directory, and paste its (automatically copied to clipboard) results here:
+
+`npx envinfo@latest --preset apollo --clipboard`
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,8 @@
+---
+name: 🚀 Feature Request
+about: Feature requests are managed in the Apollo Feature Request repo (https://github.com/apollographql/apollo-feature-requests).
+---
+
+Thanks for your interest in helping make React Apollo better!
+
+Feature requests and non-bug related discussions are no longer managed in this repo. Feature requests should be opened in https://github.com/apollographql/apollo-feature-requests.

--- a/.github/ISSUE_TEMPLATE/question-discussion.md
+++ b/.github/ISSUE_TEMPLATE/question-discussion.md
@@ -1,0 +1,10 @@
+---
+name: 🤗 Question / Discussion
+about: Questions / discussions are best posted in Apollo's Spectrum community or StackOverflow.
+---
+
+Need help or want to talk all things React Apollo? Issues here are reserved for bugs, but one of the following resources should help:
+
+* Apollo Spectrum community: https://spectrum.chat/apollo
+* StackOverflow (`react-apollo` tag): https://stackoverflow.com/questions/tagged/react-apollo
+* Apollo Feature Request repo: https://github.com/apollographql/apollo-feature-requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ If you have a more complicated issue where it is helpful to run it locally, you 
 
 Improving the documentation, examples, and other open source content can be the easiest way to contribute to the library. If you see a piece of content that can be better, open a PR with an improvement, no matter how small! If you would like to suggest a big change or major rewrite, we’d love to hear your ideas but please open an issue for discussion before writing the PR.
 
+Improving the documentation, examples, and other open source content can be the easiest way to contribute to the library. If you see a piece of content that can be better, open a PR with an improvement, no matter how small! If you would like to suggest a big change or major rewrite, we’d love to hear your ideas! Please open a feature request for discussion, over in the [Apollo Feature Request repo](https://github.com/apollographql/apollo-feature-requests), before writing the PR.
+
 ### Responding to issues
 
 In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" on Apollo Slack!
@@ -45,17 +47,11 @@ In addition to reporting issues, a great way to contribute to Apollo is to respo
 
 For a small bug fix change (less than 20 lines of code changed), feel free to open a pull request. We’ll try to merge it as fast as possible and ideally publish a new release on the same day. The only requirement is, make sure you also add a test that verifies the bug you are trying to fix.
 
-### Suggesting features
+### Suggesting feature
 
-Most of the features in Apollo came from suggestions by you, the community! We welcome any ideas about how to make Apollo better for your use case. Unless there is overwhelming demand for a feature, it might not get implemented immediately, but please include as much information as possible that will help people have a discussion about your proposal:
+Most of the features in React Apollo came from suggestions by you, the community! We welcome any ideas about how to make Apollo better for your use case. Head on over to the [Apollo Feature Request repo](https://github.com/apollographql/apollo-feature-requests), and open up a new feature request / discussion issue with your details.
 
-1. **Use case:** What are you trying to accomplish, in specific terms? Often, there might already be a good way to do what you need and a new feature is unnecessary, but it’s hard to know without information about the specific use case.
-2. **Could this be a plugin?** In many cases, a feature might be too niche to be included in the core of a library, and is better implemented as a companion package. If there isn’t a way to extend the library to do what you want, could we add additional plugin APIs? It’s important to make the case for why a feature should be part of the core functionality of the library.
-3. **Is there a workaround?** Is this a more convenient way to do something that is already possible, or is there some blocker that makes a workaround unfeasible?
-
-Feature requests will be labeled as such, and we encourage using GitHub issues as a place to discuss new features and possible implementation designs. Please refrain from submitting a pull request to implement a proposed feature until there is consensus that it should be included. This way, you can avoid putting in work that can’t be merged in.
-
-Once there is a consensus on the need for a new feature, proceed as listed below under “Big PRs”.
+**Note:** Feature requests and non-bug related discussions are no longer managed in this repo's issue tracker. Feature request and/or discussions opened here will be closed.
 
 ## Big PRs
 
@@ -66,7 +62,7 @@ This includes:
 
 For significant changes to a repository, it’s important to settle on a design before starting on the implementation. This way, we can make sure that major improvements get the care and attention they deserve. Since big changes can be risky and might not always get merged, it’s good to reduce the amount of possible wasted effort by agreeing on an implementation design/plan first.
 
-1. **Open an issue.** Open an issue about your bug or feature, as described above.
+1. **Open an issue.** Open an issue about your bug in this repo, or about your feature request in the [Apollo Feature Request repo](https://github.com/apollographql/apollo-feature-requests).
 2. **Reach consensus.** Some contributors and community members should reach an agreement that this feature or bug is important, and that someone should work on implementing or fixing it.
 3. **Agree on intended behavior.** On the issue, reach an agreement about the desired behavior. In the case of a bug fix, it should be clear what it means for the bug to be fixed, and in the case of a feature, it should be clear what it will be like for developers to use the new feature.
 4. **Agree on implementation plan.** Write a plan for how this feature or bug fix should be implemented. What modules need to be added or rewritten? Should this be one pull request or multiple incremental improvements? Who is going to do each part?


### PR DESCRIPTION
Adjust the new issue page to show multiple options, making sure it's clear that feature requests should be opened in the Apollo FR repo.
