### PR TITLE
Conditionally use AC's `ObservableQuery.resetQueryStoreErrors`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 # Change log
 
-## vNext
+## 2.5.8 (2019-06-21)
+
+### Bug Fixes
+
+- Makes the use of `apollo-client` 2.6.3's `ObservableQuery.resetQueryStoreErrors`
+  method optional, for people who can't update to `react-apollo`'s new
+  `apollo-client` peer dep of 2.6.3.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#3151](https://github.com/apollographql/react-apollo/pull/3151)
 
 ## 2.5.7 (2019-06-21)
 


### PR DESCRIPTION
To fix issue #3090, the `ObservableQuery.resetQueryStoreErrors` method was introduced in `apollo-client` 2.6.3. While `apollo-client` 2.6.3 is a peer dep of the latest version of `react-apollo` (2.5.7), people who can't update their version of `apollo-client` to >= 2.6.3 are running into issues when updating to the latest version of `react-apollo`, since `ObservableQuery.resetQueryStoreErrors` isn't available to them. Since we can't enforce the version of `apollo-client` people are using, this commit adjusts the `Query` component to only use `resetQueryStoreErrors` if it's available. If it isn't, it will call into the `ObservableQuery`'s private API to do the same things as `resetQueryStoreErrors`. This is a hack, but it is temporary as `react-apollo` is launching soon, and will enforce a minimum `apollo-client` version of 2.6.3 (so this workaround won't be needed).

Fixes #3148.