### PR TITLE
Make sure `useSubscription` cleans up when done

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3820B"
+      "maxSize": "3900B"
     }
   ],
   "renovate": {

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -52,7 +52,7 @@ export class MutationData<
     return this.unmount.bind(this);
   }
 
-  protected cleanup() {
+  public cleanup() {
     // No cleanup required.
   }
 

--- a/packages/hooks/src/data/OperationData.ts
+++ b/packages/hooks/src/data/OperationData.ts
@@ -38,9 +38,8 @@ export abstract class OperationData<TOptions = any> {
   }
 
   public abstract execute(...args: any): any;
-  public abstract afterExecute(...args: any): () => void;
-
-  protected abstract cleanup(): void;
+  public abstract afterExecute(...args: any): void | (() => void);
+  public abstract cleanup(): void;
 
   protected unmount() {
     this.isMounted = false;

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -103,7 +103,7 @@ export class QueryData<TData, TVariables> extends OperationData {
     return this.unmount.bind(this);
   }
 
-  protected cleanup() {
+  public cleanup() {
     this.removeQuerySubscription();
     this.currentObservable.query = null;
     this.previousData.result = null;

--- a/packages/hooks/src/data/SubscriptionData.ts
+++ b/packages/hooks/src/data/SubscriptionData.ts
@@ -58,10 +58,9 @@ export class SubscriptionData<
 
   public afterExecute() {
     this.isMounted = true;
-    return this.unmount.bind(this);
   }
 
-  protected cleanup() {
+  public cleanup() {
     this.endSubscription();
     delete this.currentObservable.query;
   }

--- a/packages/hooks/src/useSubscription.ts
+++ b/packages/hooks/src/useSubscription.ts
@@ -36,6 +36,7 @@ export function useSubscription<TData = any, TVariables = OperationVariables>(
   subscriptionData.context = context;
 
   useEffect(() => subscriptionData.afterExecute());
+  useEffect(() => subscriptionData.cleanup.bind(subscriptionData), []);
 
   return subscriptionData.execute(result);
 }


### PR DESCRIPTION
The `useSubscription` Hook isn't properly restting/removing the internal `ObservableQuery` instance it uses, when it's no longer needed. This means that the subscription used by the hook is never properly shut down, leading to unnecessary network communication. This PR ensures that the `useSubscription` internals are properly cleansed when the component wrapping the hook is unmounted.

Fixes #3160.