### PR TITLE
remove apollo-utilities in favor of just the isEqual needs from the shared root

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -20,15 +20,16 @@ const defaultGlobals = {
   'apollo-cache': 'apolloCache',
   'apollo-cache-inmemory': 'apolloCacheInMemory',
   'apollo-link': 'apolloLink',
-  'graphql': 'graphql',
+  graphql: 'graphql',
   'react-apollo': 'reactApollo',
-  'react': 'React',
+  react: 'React',
   'ts-invariant': 'invariant',
-  'tslib': 'tslib',
+  tslib: 'tslib',
   'fast-json-stable-stringify': 'stringify',
   'zen-observable': 'zenObservable',
   'hoist-non-react-statics': 'hoistNonReactStatics',
   'prop-types': 'PropTypes',
+  '@wry/equality': 'equal',
 };
 
 export function rollup({

--- a/examples/hooks/client/src/index.tsx
+++ b/examples/hooks/client/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloClient } from 'apollo-client';
-import { getMainDefinition } from 'apollo-utilities';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloLink, split } from 'apollo-link';
 import { HttpLink } from 'apollo-link-http';
@@ -26,12 +25,11 @@ const wsLink = new WebSocketLink({
 });
 
 const terminatingLink = split(
-  ({ query }) => {
-    const { kind, operation } = getMainDefinition(
-      query
-    ) as OperationDefinitionNode;
-    return kind === 'OperationDefinition' && operation === 'subscription';
-  },
+  ({ query: { definitions } }) =>
+    definitions.some(node => {
+      const { kind, operation } = node as OperationDefinitionNode;
+      return kind === 'OperationDefinition' && operation === 'subscription';
+    }),
   wsLink,
   httpLink
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "version": "file:packages/hooks",
       "requires": {
         "@apollo/react-common": "file:packages/common",
-        "apollo-utilities": "^1.3.2",
+        "@wry/equality": "^0.1.9",
         "ts-invariant": "^0.4.4",
         "tslib": "^1.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -82,22 +82,22 @@
     {
       "name": "@apollo/react-components",
       "path": "./packages/components/lib/react-components.cjs.min.js",
-      "maxSize": "680B"
+      "maxSize": "630B"
     },
     {
       "name": "@apollo/react-hoc",
       "path": "./packages/hoc/lib/react-hoc.cjs.min.js",
-      "maxSize": "1660B"
+      "maxSize": "1.55 kB"
     },
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3900B"
+      "maxSize": "3.6 kB"
     },
     {
       "name": "@apollo/react-ssr",
       "path": "./packages/ssr/lib/react-ssr.cjs.min.js",
-      "maxSize": "450B"
+      "maxSize": "440B"
     }
   ],
   "renovate": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@apollo/react-common": "file:../common",
-    "apollo-utilities": "^1.3.2",
+    "@wry/equality": "^0.1.9",
     "ts-invariant": "^0.4.4",
     "tslib": "^1.10.0"
   },

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -1,5 +1,5 @@
 import { ApolloError } from 'apollo-client';
-import { isEqual } from 'apollo-utilities';
+import { equal as isEqual } from '@wry/equality';
 import {
   ApolloContextValue,
   DocumentType,

--- a/packages/hooks/src/data/OperationData.ts
+++ b/packages/hooks/src/data/OperationData.ts
@@ -1,5 +1,5 @@
 import { ApolloClient } from 'apollo-client';
-import { isEqual } from 'apollo-utilities';
+import { equal as isEqual } from '@wry/equality';
 import { invariant } from 'ts-invariant';
 import {
   ApolloContextValue,

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -4,7 +4,7 @@ import {
   ApolloError,
   NetworkStatus
 } from 'apollo-client';
-import { isEqual } from 'apollo-utilities';
+import { equal as isEqual } from '@wry/equality';
 import {
   ApolloContextValue,
   DocumentType,

--- a/packages/hooks/src/data/SubscriptionData.ts
+++ b/packages/hooks/src/data/SubscriptionData.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'apollo-utilities';
+import { equal as isEqual } from '@wry/equality';
 import { ApolloContextValue, SubscriptionResult } from '@apollo/react-common';
 
 import { OperationData } from './OperationData';


### PR DESCRIPTION
After talking with @hwillson, this seems like a pretty easy swap to thin out the package by quite a lot! Let's see what bundlesize says after its done though...