### PR TITLE
Adjust `useMutation` result tuple to be more inline with React Core

### DIFF
--- a/examples/hooks/client/package.json
+++ b/examples/hooks/client/package.json
@@ -9,7 +9,7 @@
     "@types/react": "16.8.18",
     "@types/react-dom": "16.8.4",
     "apollo-cache-inmemory": "^1.6.0",
-    "apollo-client": "^2.6.0",
+    "apollo-client": "^2.6.3",
     "apollo-link-http": "^1.5.14",
     "apollo-link-ws": "^1.0.17",
     "graphql": "^14.3.1",

--- a/examples/hooks/client/src/NewRocketForm.tsx
+++ b/examples/hooks/client/src/NewRocketForm.tsx
@@ -27,7 +27,7 @@ export function NewRocketForm() {
   const [year, setYear] = useState(0);
   const [stock, setStock] = useState(0);
 
-  const [saveRocket, { error, data }] = useMutation<
+  const [{ error, data }, saveRocket] = useMutation<
     {
       saveRocket: RocketInventory;
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3.7 kB"
+      "maxSize": "3.9 kB"
     },
     {
       "name": "@apollo/react-ssr",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "postinstall": "npx lerna exec -- npm install --package-lock=false && npx lerna run prepare",
     "build": "npx lerna run build",
-    "test": "npx jest --config ./config/jest.config.js",
+    "test": "npx jest --config ./config/jest.config.js --silent",
     "test:watch": "npx jest --config ./config/jest.config.js --watch",
     "test:coverage": "npx jest --config ./config/jest.config.js --verbose --coverage",
     "test:ci": "npm run test:coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",

--- a/packages/components/src/Mutation.tsx
+++ b/packages/components/src/Mutation.tsx
@@ -7,7 +7,7 @@ import { MutationComponentOptions } from './types';
 export function Mutation<TData = any, TVariables = OperationVariables>(
   props: MutationComponentOptions<TData, TVariables>
 ) {
-  const [runMutation, result] = useMutation(props.mutation, props);
+  const [result, runMutation] = useMutation(props.mutation, props);
   return props.children ? props.children(runMutation, result) : null;
 }
 
@@ -27,6 +27,6 @@ export namespace Mutation {
     children: PropTypes.func.isRequired,
     onCompleted: PropTypes.func,
     onError: PropTypes.func,
-    fetchPolicy: PropTypes.string,
+    fetchPolicy: PropTypes.string
   };
 }

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -14,10 +14,12 @@ React Apollo [Hooks](https://reactjs.org/docs/hooks-intro.html).
 
 1. [Installation](#installation)
 2. [Hooks Overview](#hooks-overview)
-  - [`useQuery`](#useQuery)
-  - [`useMutation`](#useMutation)
-  - [`useSubscription`](#useSubscription)
-  - [`useApolloClient`](#useApolloClient)
+
+- [`useQuery`](#useQuery)
+- [`useMutation`](#useMutation)
+- [`useSubscription`](#useSubscription)
+- [`useApolloClient`](#useApolloClient)
+
 3. [Reference]()
 
 ### Installation
@@ -29,6 +31,7 @@ npm install @apollo/react-hooks
 ### Hooks Overview
 
 <a name="useQuery"></a>
+
 #### a) [`useQuery`](https://github.com/apollographql/react-apollo/blob/release-3.0.0/packages/hooks/src/useQuery.ts)
 
 **Function:**
@@ -37,7 +40,7 @@ npm install @apollo/react-hooks
 export function useQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: QueryHookOptions<TData, TVariables>
-): QueryResult<TData, TVariables>
+): QueryResult<TData, TVariables>;
 ```
 
 **Options:**
@@ -122,6 +125,7 @@ export function RocketInventoryList() {
 ```
 
 <a name="useMutation"></a>
+
 #### b) [`useMutation`](https://github.com/apollographql/react-apollo/blob/release-3.0.0/packages/hooks/src/useMutation.ts)
 
 **Function:**
@@ -130,7 +134,7 @@ export function RocketInventoryList() {
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<TData, TVariables>
-): MutationTuple<TData, TVariables>
+): MutationTuple<TData, TVariables>;
 ```
 
 **Options:**
@@ -156,16 +160,16 @@ ignoreResults?: boolean;
 
 ```ts
 [
-  (
-    options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | ExecutionResult<TData>>,
   {
     data?: TData;
     error?: ApolloError;
     loading: boolean;
     called: boolean;
     client?: ApolloClient<object>
-  }
+  },
+  (
+    options?: MutationFunctionOptions<TData, TVariables>
+  ) => Promise<void | ExecutionResult<TData>>
 ];
 ```
 
@@ -261,6 +265,7 @@ export function NewRocketForm() {
 ```
 
 <a name="useSubscription"></a>
+
 #### c) [`useSubscription`](https://github.com/apollographql/react-apollo/blob/release-3.0.0/packages/hooks/src/useSubscription.ts)
 
 **Function:**
@@ -269,7 +274,7 @@ export function NewRocketForm() {
 export function useSubscription<TData = any, TVariables = OperationVariables>(
   subscription: DocumentNode,
   options?: SubscriptionHookOptions<TData, TVariables>
-)
+);
 ```
 
 **Options:**
@@ -311,12 +316,13 @@ export function LatestNews() {
 ```
 
 <a name="useApolloClient"></a>
+
 #### d) [`useApolloClient`](https://github.com/apollographql/react-apollo/blob/release-3.0.0/packages/hooks/src/useApolloClient.ts)
 
 **Function:**
 
 ```ts
-export function useApolloClient(): ApolloClient<object>
+export function useApolloClient(): ApolloClient<object>;
 ```
 
 **Result:**
@@ -335,7 +341,3 @@ consol.log('AC instance stored in the Context', client);
 - Main [Apollo Client / React Apollo documentation](https://www.apollographql.com/docs/react/)
 - `useQuery`, `useMutation` and `useSubscription` [Hooks demo app](https://github.com/apollographql/react-apollo/tree/release-3.0.0/examples/hooks)
 - Need help? Join us in the [Apollo Spectrum community](https://spectrum.chat/apollo)
-
-
-
-

--- a/packages/hooks/src/__tests__/useMutation.test.tsx
+++ b/packages/hooks/src/__tests__/useMutation.test.tsx
@@ -44,7 +44,7 @@ describe('useMutation Hook', () => {
 
     let renderCount = 0;
     const Component = () => {
-      const [createTodo, { loading, data }] = useMutation(mutation);
+      const [{ loading, data }, createTodo] = useMutation(mutation);
       switch (renderCount) {
         case 0:
           expect(loading).toBeFalsy();
@@ -109,7 +109,7 @@ describe('useMutation Hook', () => {
 
     let renderCount = 0;
     const useCreateTodo = () => {
-      const [createTodo, { loading, data }] = useMutation(mutation);
+      const [{ loading, data }, createTodo] = useMutation(mutation);
 
       useEffect(() => {
         createTodo({ variables });

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -44,7 +44,7 @@ export class MutationData<
     const runMutation = (
       options?: MutationFunctionOptions<TData, TVariables>
     ) => this.runMutation(options);
-    return [runMutation, result] as MutationTuple<TData, TVariables>;
+    return [result, runMutation] as MutationTuple<TData, TVariables>;
   }
 
   public afterExecute() {

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -66,10 +66,10 @@ export interface MutationOptions<TData = any, TVariables = OperationVariables>
 }
 
 export type MutationTuple<TData, TVariables> = [
+  MutationResult<TData>,
   (
     options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | ExecutionResult<TData>>,
-  MutationResult<TData>
+  ) => Promise<void | ExecutionResult<TData>>
 ];
 
 /* Subscription types */

--- a/packages/hooks/src/useMutation.ts
+++ b/packages/hooks/src/useMutation.ts
@@ -1,6 +1,7 @@
 import { useContext, useState, useRef, useEffect } from 'react';
 import { getApolloContext, OperationVariables } from '@apollo/react-common';
 import { DocumentNode } from 'graphql';
+import { invariant } from 'ts-invariant';
 
 import { MutationHookOptions, MutationTuple } from './types';
 import { MutationData } from './data/MutationData';
@@ -15,7 +16,7 @@ export function useMutation<TData = any, TVariables = OperationVariables>(
   // breaking `useMutation` API change during the RA 3 beta process. It will
   // be removed before the official launch of RA 3.
   if (showApiChangeWarning) {
-    console.warn(
+    invariant.warn(
       'PLEASE NOTE: The `useMutation` API has changed; the tuple based ' +
         'return value now has the mutation result in the first position, ' +
         'e.g. [Mutation Result, Mutation Function]. See ' +

--- a/packages/hooks/src/useMutation.ts
+++ b/packages/hooks/src/useMutation.ts
@@ -5,10 +5,26 @@ import { DocumentNode } from 'graphql';
 import { MutationHookOptions, MutationTuple } from './types';
 import { MutationData } from './data/MutationData';
 
+let showApiChangeWarning = true;
+
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<TData, TVariables>
 ): MutationTuple<TData, TVariables> {
+  // This is a temporary message intended to help lessen the blow of a
+  // breaking `useMutation` API change during the RA 3 beta process. It will
+  // be removed before the official launch of RA 3.
+  if (showApiChangeWarning) {
+    console.warn(
+      'PLEASE NOTE: The `useMutation` API has changed; the tuple based ' +
+        'return value now has the mutation result in the first position, ' +
+        'e.g. [Mutation Result, Mutation Function]. See ' +
+        'https://github.com/apollographql/react-apollo/issues/3189 for the ' +
+        'reason behind this change.'
+    );
+    showApiChangeWarning = false;
+  }
+
   const context = useContext(getApolloContext());
   const [result, setResult] = useState({ called: false, loading: false });
   const updatedOptions = options ? { ...options, mutation } : { mutation };


### PR DESCRIPTION
This commit re-arranges the `useMutation` result tuple such that the mutation result is in the first position, with the mutation function in the second position. The intent of this change is to bring the `useMutation` Hook more in-line with how the React Core handles its Hook results (e.g. `useState`, `useReducer`).

**This is a breaking change, but since we're in beta hopefully that's okay.** To help lessen the blow a bit this commit includes changes to display a `console.warn` message describing the API changes. This message will be removed before the final version of React Apollo 3 is published.

Fixes #3189.