### PR TITLE
Switch back to the mutation function in first tuple position

### DIFF
--- a/examples/hooks/client/src/NewRocketForm.tsx
+++ b/examples/hooks/client/src/NewRocketForm.tsx
@@ -27,7 +27,7 @@ export function NewRocketForm() {
   const [year, setYear] = useState(0);
   const [stock, setStock] = useState(0);
 
-  const [{ error, data }, saveRocket] = useMutation<
+  const [saveRocket, { error, data }] = useMutation<
     {
       saveRocket: RocketInventory;
     },

--- a/packages/components/src/Mutation.tsx
+++ b/packages/components/src/Mutation.tsx
@@ -7,7 +7,7 @@ import { MutationComponentOptions } from './types';
 export function Mutation<TData = any, TVariables = OperationVariables>(
   props: MutationComponentOptions<TData, TVariables>
 ) {
-  const [result, runMutation] = useMutation(props.mutation, props);
+  const [runMutation, result] = useMutation(props.mutation, props);
   return props.children ? props.children(runMutation, result) : null;
 }
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -160,16 +160,16 @@ ignoreResults?: boolean;
 
 ```ts
 [
+  (
+    options?: MutationFunctionOptions<TData, TVariables>
+  ) => Promise<void | ExecutionResult<TData>>,
   {
     data?: TData;
     error?: ApolloError;
     loading: boolean;
     called: boolean;
     client?: ApolloClient<object>
-  },
-  (
-    options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | ExecutionResult<TData>>
+  }
 ];
 ```
 

--- a/packages/hooks/src/__tests__/useMutation.test.tsx
+++ b/packages/hooks/src/__tests__/useMutation.test.tsx
@@ -44,7 +44,7 @@ describe('useMutation Hook', () => {
 
     let renderCount = 0;
     const Component = () => {
-      const [{ loading, data }, createTodo] = useMutation(mutation);
+      const [createTodo, { loading, data }] = useMutation(mutation);
       switch (renderCount) {
         case 0:
           expect(loading).toBeFalsy();
@@ -109,7 +109,7 @@ describe('useMutation Hook', () => {
 
     let renderCount = 0;
     const useCreateTodo = () => {
-      const [{ loading, data }, createTodo] = useMutation(mutation);
+      const [createTodo, { loading, data }] = useMutation(mutation);
 
       useEffect(() => {
         createTodo({ variables });

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -45,7 +45,7 @@ export class MutationData<
     const runMutation = (
       options?: MutationFunctionOptions<TData, TVariables>
     ) => this.runMutation(options);
-    return [result, runMutation] as MutationTuple<TData, TVariables>;
+    return [runMutation, result] as MutationTuple<TData, TVariables>;
   }
 
   public afterExecute() {

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -84,10 +84,10 @@ export interface MutationOptions<TData = any, TVariables = OperationVariables>
 }
 
 export type MutationTuple<TData, TVariables> = [
-  MutationResult<TData>,
   (
     options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | ExecutionResult<TData>>
+  ) => Promise<void | ExecutionResult<TData>>,
+  MutationResult<TData>
 ];
 
 /* Subscription types */

--- a/packages/hooks/src/useMutation.ts
+++ b/packages/hooks/src/useMutation.ts
@@ -1,31 +1,14 @@
 import { useContext, useState, useRef, useEffect } from 'react';
 import { getApolloContext, OperationVariables } from '@apollo/react-common';
 import { DocumentNode } from 'graphql';
-import { invariant } from 'ts-invariant';
 
 import { MutationHookOptions, MutationTuple } from './types';
 import { MutationData } from './data/MutationData';
-
-let showApiChangeWarning = true;
 
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<TData, TVariables>
 ): MutationTuple<TData, TVariables> {
-  // This is a temporary message intended to help lessen the blow of a
-  // breaking `useMutation` API change during the RA 3 beta process. It will
-  // be removed before the official launch of RA 3.
-  if (showApiChangeWarning) {
-    invariant.warn(
-      'PLEASE NOTE: The `useMutation` API has changed; the tuple based ' +
-        'return value now has the mutation result in the first position, ' +
-        'e.g. [Mutation Result, Mutation Function]. See ' +
-        'https://github.com/apollographql/react-apollo/issues/3189 for the ' +
-        'reason behind this change.'
-    );
-    showApiChangeWarning = false;
-  }
-
   const context = useContext(getApolloContext());
   const [result, setResult] = useState({ called: false, loading: false });
   const updatedOptions = options ? { ...options, mutation } : { mutation };


### PR DESCRIPTION
While the changes requested in #3189 and implemented in #3199 seemed like a good idea, we no longer think it makes sense for React Apollo to align its hooks API with React's core hooks API. In `useMutation`'s case, the mutation function will almost always be called, whereas the results aren't necessarily used. For this reason it makes sense to keep the mutation function in the first position of the result tuple.