### PR TITLE
Fix incorrect `optimisticResponse` types

### DIFF
--- a/packages/common/src/types/types.ts
+++ b/packages/common/src/types/types.ts
@@ -93,7 +93,7 @@ export interface BaseMutationOptions<
   TVariables = OperationVariables
 > {
   variables?: TVariables;
-  optimisticResponse?: TData;
+  optimisticResponse?: TData | ((vars: TVariables) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   errorPolicy?: ErrorPolicy;
@@ -112,7 +112,7 @@ export interface MutationFunctionOptions<
   TVariables = OperationVariables
 > {
   variables?: TVariables;
-  optimisticResponse?: TData;
+  optimisticResponse?: TData | ((vars: TVariables | {}) => TData);
   refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
   awaitRefetchQueries?: boolean;
   update?: MutationUpdaterFn<TData>;

--- a/packages/components/src/Mutation.tsx
+++ b/packages/components/src/Mutation.tsx
@@ -15,7 +15,7 @@ export namespace Mutation {
   export const propTypes = {
     mutation: PropTypes.object.isRequired,
     variables: PropTypes.object,
-    optimisticResponse: PropTypes.object,
+    optimisticResponse: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     refetchQueries: PropTypes.oneOfType([
       PropTypes.arrayOf(
         PropTypes.oneOfType([PropTypes.string, PropTypes.object])

--- a/packages/hoc/src/mutation-hoc.tsx
+++ b/packages/hoc/src/mutation-hoc.tsx
@@ -80,10 +80,10 @@ export function withMutation<
               const resultName = operationOptions.name
                 ? `${name}Result`
                 : 'result';
-              let childProps = {
+              let childProps = ({
                 [name]: mutate,
                 [resultName]: result
-              } as any as TChildProps;
+              } as any) as TChildProps;
               if (operationOptions.props) {
                 const newResult: OptionProps<
                   TProps,
@@ -97,9 +97,7 @@ export function withMutation<
                 childProps = operationOptions.props(newResult) as any;
               }
 
-              return (
-                <WrappedComponent {...props} {...childProps} />
-              );
+              return <WrappedComponent {...props} {...childProps} />;
             }}
           </Mutation>
         );

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -142,7 +142,7 @@ export function useMutation<TData = any, TVariables = OperationVariables>(
 ```ts
 mutation?: DocumentNode;
 variables?: TVariables;
-optimisticResponse?: TData;
+optimisticResponse?: TData | ((vars: TVariables) => TData);
 refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction;
 awaitRefetchQueries?: boolean;
 errorPolicy?: ErrorPolicy;


### PR DESCRIPTION
Apollo Client was updated a while back to allow both objects and functions as an `optimisticResponse` option. This commit updates React Apollo accordingly.

Fixes #3248.
