### PR TITLE
Prevent ObservableQuery component updates from being blocked

### DIFF
--- a/packages/components/src/Query.tsx
+++ b/packages/components/src/Query.tsx
@@ -25,6 +25,6 @@ export namespace Query {
     variables: PropTypes.object,
     ssr: PropTypes.bool,
     partialRefetch: PropTypes.bool,
-    returnPartialData: PropTypes.bool,
+    returnPartialData: PropTypes.bool
   };
 }

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -189,12 +189,6 @@ export class QueryData<TData, TVariables> extends OperationData {
     return result;
   }
 
-  private updateCurrentData() {
-    if (this.isMounted) {
-      this.forceUpdate();
-    }
-  }
-
   private prepareObservableQueryOptions() {
     this.verifyDocumentType(this.getOptions().query, DocumentType.Query);
     const displayName = this.getOptions().displayName || 'Query';
@@ -286,12 +280,12 @@ export class QueryData<TData, TVariables> extends OperationData {
           return;
         }
 
-        this.updateCurrentData();
+        this.forceUpdate();
       },
       error: error => {
         this.resubscribeToQuery();
         if (!error.hasOwnProperty('graphQLErrors')) throw error;
-        this.updateCurrentData();
+        this.forceUpdate();
       }
     });
   }


### PR DESCRIPTION
When new data or errors are reported back through the `ObservableQuery` subscription, `updateCurrentData` is called to trigger a forced update of the parent component (to reflect the new component state). Before triggering the forced update however, `updateCurrentData` first checks to see if the component is mounted (since we don't want to try to trigger a forced update on a copmonent that isn't mounted). Unfortunately, a component isn't marked as being mounted until the `afterExecute` method is called via a `useEffect`. Under certain circumstances it's possible for the `ObservableQuery` subscription to be initialized and get data back before the `useEffect` has fired and marked the component as mounted. This means when `updateCurrentData` is triggered with valid updates, they're sometimes blocked, and the component gets stuck in a permanent loading state.

Due to other recent cleanup changes, we're now tracking the destruction of the `ObservableQuery` subscription in a `useEffect` within `useBaseQuery`. The subscription cleanup is fired only when the component unmounts, and since we're only calling `updateCurrentData` from within the subscription callback, we don't need to have an extra `isMounted` check before forcing an update. To this end, these changes get rid of `updateCurrentData` completely. The `ObservableQuery` subscription now always calls `forceUpdate` directly, and as long as the component is mounted (tracked by React), it will always force an update. This prevents race conditions between data attempting to be updated, and the component not yet being marked as mounted.

Fixes #3270.
Fixes #3299.