### PR TITLE
Add missing `useLazyQuery` export to `react-apollo`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 3.0.1 (TBD)
+
+## Bug Fixes
+
+- Add missing `useLazyQuery` export to the `react-apollo` (all) package. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3320](https://github.com/apollographql/react-apollo/pull/3320)
+
 ## 3.0.0 (2019-08-06)
 
 ### Overview

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     {
       "name": "react-apollo",
       "path": "./packages/all/lib/react-apollo.cjs.min.js",
-      "maxSize": "375B"
+      "maxSize": "380B"
     },
     {
       "name": "@apollo/react-common",

--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -56,6 +56,7 @@ export {
 // @apollo/react-hooks
 export {
   useQuery,
+  useLazyQuery,
   useMutation,
   useSubscription,
   useApolloClient,


### PR DESCRIPTION
Oops! 😳

Fixes https://github.com/apollographql/react-apollo/issues/3319.