### PR TITLE
Export `MockedProviderProps` and `MockedProviderState`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
   [@hwillson](https://github.com/hwillson) in [#3320](https://github.com/apollographql/react-apollo/pull/3320)
 - Remove `void` from being one of the `MutationTuple` mutate function possible generics. This will make it easier to properly destructure results returned by the mutate function Promise. <br/>
   [@hwillson](https://github.com/hwillson) in [#3334](https://github.com/apollographql/react-apollo/pull/3334)
+- Export `MockedProviderProps` and `MockedProviderState` from `@apollo/react-testing`. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3337](https://github.com/apollographql/react-apollo/pull/3337)
 
 ## 3.0.0 (2019-08-06)
 

--- a/packages/testing/src/mocks/MockedProvider.tsx
+++ b/packages/testing/src/mocks/MockedProvider.tsx
@@ -1,26 +1,9 @@
 import React from 'react';
-import { ApolloClient, DefaultOptions, Resolvers } from 'apollo-client';
-import { ApolloCache } from 'apollo-cache';
+import { ApolloClient } from 'apollo-client';
 import { InMemoryCache as Cache } from 'apollo-cache-inmemory';
 import { ApolloProvider } from '@apollo/react-common';
-import { ApolloLink } from 'apollo-link';
 import { MockLink } from './mockLink';
-import { MockedResponse } from './types';
-
-export interface MockedProviderProps<TSerializedCache = {}> {
-  mocks?: ReadonlyArray<MockedResponse>;
-  addTypename?: boolean;
-  defaultOptions?: DefaultOptions;
-  cache?: ApolloCache<TSerializedCache>;
-  resolvers?: Resolvers;
-  childProps?: object;
-  children?: React.ReactElement;
-  link?: ApolloLink;
-}
-
-export interface MockedProviderState {
-  client: ApolloClient<any>;
-}
+import { MockedProviderProps, MockedProviderState } from './types';
 
 export class MockedProvider extends React.Component<
   MockedProviderProps,

--- a/packages/testing/src/mocks/types.ts
+++ b/packages/testing/src/mocks/types.ts
@@ -1,4 +1,7 @@
 import { GraphQLRequest, FetchResult } from 'apollo-link';
+import { ApolloClient, DefaultOptions, Resolvers } from 'apollo-client';
+import { ApolloCache } from 'apollo-cache';
+import { ApolloLink } from 'apollo-link';
 
 export type ResultFunction<T> = () => T;
 
@@ -14,4 +17,19 @@ export interface MockedSubscriptionResult {
   result?: FetchResult;
   error?: Error;
   delay?: number;
+}
+
+export interface MockedProviderProps<TSerializedCache = {}> {
+  mocks?: ReadonlyArray<MockedResponse>;
+  addTypename?: boolean;
+  defaultOptions?: DefaultOptions;
+  cache?: ApolloCache<TSerializedCache>;
+  resolvers?: Resolvers;
+  childProps?: object;
+  children?: React.ReactElement;
+  link?: ApolloLink;
+}
+
+export interface MockedProviderState {
+  client: ApolloClient<any>;
 }


### PR DESCRIPTION
These were available in `react-apollo@2`, and there isn't any reason not to expose them.

Fixes #3336.