### PR TITLE
Add test to verify error is persisted on re-render, when appropriate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@
   [@hwillson](https://github.com/hwillson) in [#3337](https://github.com/apollographql/react-apollo/pull/3337)
 - Add `@types/react` as a peer dep, to address potential TS compilation errors when using `ApolloProvider`. <br/>
   [@zkochan](https://github.com/zkochan) in [#3278](https://github.com/apollographql/react-apollo/pull/3278)
+- Make sure `error`'s are maintained after re-renders, when they should be. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3362](https://github.com/apollographql/react-apollo/pull/3362)
 
 ## 3.0.0 (2019-08-06)
 


### PR DESCRIPTION
Issue #3295 demonstrates a problem where errors aren't maintained on re-renders, when they should still be available. This issue was fixed by PR #3339, but this commit will add an extra test to verify that the issue is indeed fixed.

Fixes #3295.
