### PR TITLE
feat(packages/hooks): export MutateFunction type

### DIFF
--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -85,10 +85,12 @@ export interface MutationOptions<TData = any, TVariables = OperationVariables>
   mutation: DocumentNode;
 }
 
+export type MutationFunction<TData, TVariables> = (
+  options?: MutationFunctionOptions<TData, TVariables>,
+) => Promise<ExecutionResult<TData>>;
+
 export type MutationTuple<TData, TVariables> = [
-  (
-    options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<ExecutionResult<TData>>,
+  MutationFunction<TData, TVariables>,
   MutationResult<TData>
 ];
 


### PR DESCRIPTION
Howdy! When using the useMutation function and typescript we are typing the mutate function like this:
```ts
const [mutateSomething] = useMutation(QUERY);
const handleOnClick = (mutateSomething: MutationTuple<TData, TVariables>[0]) => (idx: number) => {
 return mutateSomething()
}

```

This PR will allow us to clean up the types a bit and write the same thing as 

```ts
const [mutateSomething] = useMutation(QUERY);
const handleOnClick = (mutateSomething: MutationFunction) => (idx: number) => {
 return mutateSomething()
}

```

If there's already a better way to do this let me know!