### PR TITLE
Change the default query `data` state from `{}` to `undefined`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,13 @@
 # Change log
 
-## vNext
+## 3.1.0 (TBD)
 
 ### Bug Fixes
 
-- Documentation fixes.  <br/>
+- Change the default query `data` state from `{}` to `undefined`. This change aligns all parts of the React Apollo query cycle so that `data` is always `undefined` if there is no data, instead of `data` being converted into an empty object. This change impacts the initial query response, initial SSR response, `data` value when errors occur, `data` value when skipping, etc. All of these areas are now aligned to only ever return a value for `data` if there really is a value to return (instead of making it seem like there is one by converting to `{}`). <br/>
+  [@hwillson](https://github.com/hwillson) in [#3388](https://github.com/apollographql/react-apollo/pull/3388)
+- Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
-
 
 ## 3.0.1 (2019-08-15)
 

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-apollo",
   "description": "React Apollo Hooks, Components, and HOC.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-common",
   "description": "React Apollo common utilities.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-components",
   "description": "React Apollo Query, Mutation and Subscription components.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/components/src/__tests__/client/Query.test.tsx
+++ b/packages/components/src/__tests__/client/Query.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@apollo/react-testing';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, wait } from '@testing-library/react';
 import { ApolloLink } from 'apollo-link';
 import { Query } from '@apollo/react-components';
 
@@ -954,7 +954,7 @@ describe('Query component', () => {
       );
     });
 
-    it('onError with error', done => {
+    it('onError with error', async () => {
       const error = new Error('error occurred');
       const mockError = [
         {
@@ -965,7 +965,6 @@ describe('Query component', () => {
 
       const onErrorFunc = (queryError: ApolloError) => {
         expect(queryError.networkError).toEqual(error);
-        done();
       };
 
       const Component = () => (
@@ -981,6 +980,8 @@ describe('Query component', () => {
           <Component />
         </MockedProvider>
       );
+
+      await wait();
     });
   });
 
@@ -1958,7 +1959,7 @@ describe('Query component', () => {
             {(result: any) => {
               const { data, loading } = result;
               if (!loading) {
-                expect(data).toEqual({});
+                expect(data).toBeUndefined();
                 done();
               }
               return null;
@@ -2133,7 +2134,7 @@ describe('Query component', () => {
         <ApolloProvider client={client}>
           <Query query={partialQuery}>
             {({ data }: any) => {
-              expect(data).toEqual({});
+              expect(data).toBeUndefined();
               return null;
             }}
           </Query>

--- a/packages/components/src/__tests__/client/__snapshots__/Query.test.tsx.snap
+++ b/packages/components/src/__tests__/client/__snapshots__/Query.test.tsx.snap
@@ -21,7 +21,7 @@ Object {
 exports[`Query component calls the children prop: result in render prop while loading 1`] = `
 Object {
   "called": true,
-  "data": Object {},
+  "data": undefined,
   "error": undefined,
   "fetchMore": [Function],
   "loading": true,

--- a/packages/hoc/package.json
+++ b/packages/hoc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-hoc",
   "description": "React Apollo `graphql` higher-order component.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-hooks",
   "description": "React Apollo Hooks.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/hooks/src/__tests__/useQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useQuery.test.tsx
@@ -58,6 +58,25 @@ describe('useQuery Hook', () => {
         </MockedProvider>
       );
     });
+
+    it('should keep data as undefined until data is actually returned', done => {
+      const Component = () => {
+        const { data, loading } = useQuery(CAR_QUERY);
+        if (loading) {
+          expect(data).toBeUndefined();
+        } else {
+          expect(data).toEqual(CAR_RESULT_DATA);
+          done();
+        }
+        return null;
+      };
+
+      render(
+        <MockedProvider mocks={CAR_MOCKS}>
+          <Component />
+        </MockedProvider>
+      );
+    });
   });
 
   describe('Polling', () => {

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-ssr",
   "description": "React Apollo server-side rendering utilities",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",

--- a/packages/ssr/src/__tests__/useQuery.test.tsx
+++ b/packages/ssr/src/__tests__/useQuery.test.tsx
@@ -62,11 +62,11 @@ describe('useQuery Hook SSR', () => {
     });
   });
 
-  it('should initialize data as an empty object when loading', () => {
+  it('should initialize data as `undefined` when loading', () => {
     const Component = () => {
       const { data, loading } = useQuery(CAR_QUERY);
       if (loading) {
-        expect(data).toEqual({});
+        expect(data).toBeUndefined();
       }
       return null;
     };

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/react-testing",
   "description": "React Apollo testing utilities.",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "author": "opensource@apollographql.com",
   "keywords": [
     "apollo",


### PR DESCRIPTION
React Apollo returns an empty object for the initial `data` value, that is returned when performing a query. There a long history behind why this is the case, but this single issue has caused a lot of frustration over the past long while due to the following:

- `{}` is not the same as having no data; it's an object, not nothing. If there is no data, we shouldn't pretend there is.
- Setting `data` to `{}` isn't followed in all cases; e.g. when errors occur, during parts of SSR, when skipping, etc. This leads to developers having to know when to expect `{}` and when to expect `undefined`.
- Forcing no data situations to be empty objects can go against application schemas that enforce a value and don't allow empty objects.

This PR adjusts React Apollo's default query `data` state to be `undefined`, and will no longer convert `data` to an empty object if the returned data is falsy. Using `undefined` as the initial state has also been aligned across all parts of RA querying, including SSR.

Unfortunately, we missed the opportunity to address this as part of the React Apollo 3.0 launch. This change can be considered breaking, and we can't do another major version bump to get this
in (3.0 is the last major version of React Apollo, as React Apollo is being merged into the Apollo Client project). We'll have to put some thought into how we can roll this out.

Fixes #3323.