### PR TITLE
MockLink - Removed references to removeClientSetsFromDocument

### DIFF
--- a/packages/testing/src/mocks/mockLink.ts
+++ b/packages/testing/src/mocks/mockLink.ts
@@ -7,7 +7,6 @@ import {
 } from 'apollo-link';
 import {
   addTypenameToDocument,
-  removeClientSetsFromDocument,
   removeConnectionDirectiveFromDocument,
   cloneDeep,
   isEqual
@@ -132,10 +131,6 @@ export class MockLink extends ApolloLink {
     newMockedResponse.request.query = removeConnectionDirectiveFromDocument(
       newMockedResponse.request.query
     );
-    const query = removeClientSetsFromDocument(newMockedResponse.request.query);
-    if (query) {
-      newMockedResponse.request.query = query;
-    }
     return newMockedResponse;
   }
 }


### PR DESCRIPTION
This stops the MockLink from stripping @client directives from query sets

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

