### PR TITLE
add client to the mutation result

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
   [@hwillson](https://github.com/hwillson) in [#3422](https://github.com/apollographql/react-apollo/pull/3422)
 - Fixed problematic re-renders that were caused by using `fetchMore.updateQuery` with `notifyOnNetworkStatusChange` set to true. When `notifyOnNetworkStatusChange` is true, re-renders will now wait until `updateQuery` has completed, to make sure the updated data is used during the render. <br/>
   [@hwillson](https://github.com/hwillson) in [#3433](https://github.com/apollographql/react-apollo/pull/3433)
+- Add `client` to the `useMutation` result. <br/>
+  [@joshalling](https://github.com/joshalling) in [#3417](https://github.com/apollographql/react-apollo/pull/3417)
 - Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3.98 kB"
+      "maxSize": "3.99 kB"
     },
     {
       "name": "@apollo/react-ssr",

--- a/packages/hooks/src/__tests__/useMutation.test.tsx
+++ b/packages/hooks/src/__tests__/useMutation.test.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { MockedProvider, mockSingleLink } from '@apollo/react-testing';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, wait } from '@testing-library/react';
 import { ApolloProvider, useMutation } from '@apollo/react-hooks';
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
@@ -235,6 +235,23 @@ describe('useMutation Hook', () => {
           <Component />
         </MockedProvider>
       );
+    });
+
+    it('should return the current client instance in the result object', async () => {
+      const Component = () => {
+        const [, { client }] = useMutation(CREATE_TODO_MUTATION);
+        expect(client).toBeDefined();
+        expect(client instanceof ApolloClient).toBeTruthy();
+        return null;
+      };
+
+      render(
+        <MockedProvider>
+          <Component />
+        </MockedProvider>
+      );
+
+      await wait();
     });
   });
 

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -42,8 +42,7 @@ export class MutationData<
   public execute(result: MutationResult<TData>) {
     this.isMounted = true;
     this.verifyDocumentType(this.getOptions().mutation, DocumentType.Mutation);
-
-    result.client = this.client || this.refreshClient().client;
+    result.client = this.refreshClient().client;
     return [this.runMutation, result] as MutationTuple<TData, TVariables>;
   }
 

--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -42,6 +42,8 @@ export class MutationData<
   public execute(result: MutationResult<TData>) {
     this.isMounted = true;
     this.verifyDocumentType(this.getOptions().mutation, DocumentType.Mutation);
+
+    result.client = this.client || this.refreshClient().client;
     return [this.runMutation, result] as MutationTuple<TData, TVariables>;
   }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This fixes #3366 

According to the [docs](https://www.apollographql.com/docs/react/api/react-components/#mutation) the client should be in the result. This updates the result to have the client on MutationData added to the result. If the client is undefined, it will refresh it and add it on there.

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

