### PR TITLE
Ensure ObservableQuery fields have a stable identity

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@
   [@hwillson](https://github.com/hwillson) in [#3388](https://github.com/apollographql/react-apollo/pull/3388)
 - Adds support for the `skip` option when using `useSubscription`. <br/>
   [@n1ru4l](https://github.com/n1ru4l) in [#3356](https://github.com/apollographql/react-apollo/pull/3356)
+- Makes sure `refetch`, `fetchMore`, `updateQuery`, `startPolling`, `stopPolling`, and `subscribeToMore` maintain a stable identity when they're passed back alongside query results. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3422](https://github.com/apollographql/react-apollo/pull/3422)
 - Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3.93 kB"
+      "maxSize": "3.98 kB"
     },
     {
       "name": "@apollo/react-ssr",

--- a/packages/hooks/src/__tests__/useQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useQuery.test.tsx
@@ -2,7 +2,7 @@ import React, { useState, useReducer } from 'react';
 import { DocumentNode, GraphQLError } from 'graphql';
 import gql from 'graphql-tag';
 import { MockedProvider, MockLink } from '@apollo/react-testing';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, wait } from '@testing-library/react';
 import { useQuery, ApolloProvider } from '@apollo/react-hooks';
 import { ApolloClient } from 'apollo-client';
 import { ApolloLink, Observable } from 'apollo-link';
@@ -76,6 +76,50 @@ describe('useQuery Hook', () => {
           <Component />
         </MockedProvider>
       );
+    });
+
+    it('should ensure ObservableQuery fields have a stable identity', async () => {
+      let refetchFn: any;
+      let fetchMoreFn: any;
+      let updateQueryFn: any;
+      let startPollingFn: any;
+      let stopPollingFn: any;
+      let subscribeToMoreFn: any;
+      const Component = () => {
+        const {
+          loading,
+          refetch,
+          fetchMore,
+          updateQuery,
+          startPolling,
+          stopPolling,
+          subscribeToMore
+        } = useQuery(CAR_QUERY);
+        if (loading) {
+          refetchFn = refetch;
+          fetchMoreFn = fetchMore;
+          updateQueryFn = updateQuery;
+          startPollingFn = startPolling;
+          stopPollingFn = stopPolling;
+          subscribeToMoreFn = subscribeToMore;
+        } else {
+          expect(refetch).toBe(refetchFn);
+          expect(fetchMore).toBe(fetchMoreFn);
+          expect(updateQuery).toBe(updateQueryFn);
+          expect(startPolling).toBe(startPollingFn);
+          expect(stopPolling).toBe(stopPollingFn);
+          expect(subscribeToMore).toBe(subscribeToMoreFn);
+        }
+        return null;
+      };
+
+      render(
+        <MockedProvider mocks={CAR_MOCKS}>
+          <Component />
+        </MockedProvider>
+      );
+
+      await wait();
     });
   });
 


### PR DESCRIPTION
Make sure `refetch`, `fetchMore`, `updateQuery`, `startPolling`, `stopPolling`, and `subscribeToMore` maintain a stable identity when they're passed back alongside query results.

Fixes #3317.