### PR TITLE
Fix problematic `fetchMore` `notifyOnNetworkStatusChange` renders

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
   [@n1ru4l](https://github.com/n1ru4l) in [#3356](https://github.com/apollographql/react-apollo/pull/3356)
 - Makes sure `refetch`, `fetchMore`, `updateQuery`, `startPolling`, `stopPolling`, and `subscribeToMore` maintain a stable identity when they're passed back alongside query results. <br/>
   [@hwillson](https://github.com/hwillson) in [#3422](https://github.com/apollographql/react-apollo/pull/3422)
+- Fixed problematic re-renders that were caused by using `fetchMore.updateQuery` with `notifyOnNetworkStatusChange` set to true. When `notifyOnNetworkStatusChange` is true, re-renders will now wait until `updateQuery` has completed, to make sure the updated data is used during the render. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3433](https://github.com/apollographql/react-apollo/pull/3433)
 - Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
 
@@ -74,6 +76,7 @@ Consult the [Hooks migration guide](https://www.apollographql.com/docs/react/hoo
   ```js
   import * as compose from 'lodash.flowright';
   ```
+
 - Render prop components (`Query`, `Mutation` and `Subscription`) can no longer be extended. In other words, this is no longer possible:
 
   ```js
@@ -93,7 +96,6 @@ Consult the [Hooks migration guide](https://www.apollographql.com/docs/react/hoo
     </Query>
   );
   ```
-
 
 ## 2.5.7 (2019-06-21)
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "name": "@apollo/react-hooks",
       "path": "./packages/hooks/lib/react-hooks.cjs.min.js",
-      "maxSize": "3.98 kB"
+      "maxSize": "4 kB"
     },
     {
       "name": "@apollo/react-ssr",

--- a/packages/hoc/src/__tests__/queries/skip.test.tsx
+++ b/packages/hoc/src/__tests__/queries/skip.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, wait } from '@testing-library/react';
 import gql from 'graphql-tag';
 import ApolloClient from 'apollo-client';
 import { ApolloLink } from 'apollo-link';
@@ -555,7 +555,7 @@ describe('[queries] skip', () => {
     );
   });
 
-  it('allows you to skip then unskip a query with opts syntax', done => {
+  it('allows you to skip then unskip a query with opts syntax', async () => {
     const query: DocumentNode = gql`
       query people {
         allPeople(first: 1) {
@@ -627,7 +627,6 @@ describe('[queries] skip', () => {
               break;
             case 4:
               expect(this.props.data!.loading).toBeFalsy();
-              done();
               break;
             default:
           }
@@ -654,9 +653,13 @@ describe('[queries] skip', () => {
         <Parent />
       </ApolloProvider>
     );
+
+    await wait(() => {
+      expect(count).toEqual(5);
+    });
   });
 
-  it('removes the injected props if skip becomes true', done => {
+  it('removes the injected props if skip becomes true', async () => {
     let count = 0;
     const query: DocumentNode = gql`
       query people($first: Int) {
@@ -697,17 +700,12 @@ describe('[queries] skip', () => {
       class extends React.Component<ChildProps<Vars, Data>> {
         componentDidUpdate() {
           const { data } = this.props;
-          try {
-            // loading is true, but data still there
-            if (count === 0)
-              expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
-            if (count === 1) expect(data).toBeUndefined();
-            if (count === 2 && !data!.loading) {
-              expect(stripSymbols(data!.allPeople)).toEqual(data3.allPeople);
-              done();
-            }
-          } catch (error) {
-            done.fail(error);
+          // loading is true, but data still there
+          if (count === 0)
+            expect(stripSymbols(data!.allPeople)).toEqual(data1.allPeople);
+          if (count === 1) expect(data).toBeUndefined();
+          if (count === 2 && !data!.loading) {
+            expect(stripSymbols(data!.allPeople)).toEqual(data3.allPeople);
           }
         }
         render() {
@@ -740,6 +738,10 @@ describe('[queries] skip', () => {
         <ChangingProps />
       </ApolloProvider>
     );
+
+    await wait(() => {
+      expect(count).toEqual(2);
+    });
   });
 
   it('allows you to unmount a skipped query', done => {


### PR DESCRIPTION
Prior to this PR, when `notifyOnNetworkStatusChange` is true calls to `fetchMore` do not wait for `updateQuery` to finish, before triggering a re-render. This means that after a `fetchMore` call, components will flip to `loading: true`, then `loading: false`,  then un-necessarily re-render once more as `loading: false` with the result from `updateQuery`. This commit adds a check to see if `fetchMore` has been called and then holds off on re-rendering the `loading: false` state, until `updateQuery` has fully finished. 

Fixes #3333