### PR TITLE
Remove `void` from `MutationFunction` Promise return type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@
   [@hwillson](https://github.com/hwillson) in [#3453](https://github.com/apollographql/react-apollo/pull/3453)
 - SSR enhancements to support `network-only` and `cache-and-network` fetch policies, along with changes to ensure disabled SSR queries are not fired. <br/>
   [@mikebm](https://github.com/mikebm) in [#3435](https://github.com/apollographql/react-apollo/pull/3435)
+- Remove `void` from the `MutationFunction`'s returned Promise types. <br/>
+  [@hwillson](https://github.com/hwillson) in [#TODO](https://github.com/apollographql/react-apollo/pull/TODO)
 - Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,7 @@
 - SSR enhancements to support `network-only` and `cache-and-network` fetch policies, along with changes to ensure disabled SSR queries are not fired. <br/>
   [@mikebm](https://github.com/mikebm) in [#3435](https://github.com/apollographql/react-apollo/pull/3435)
 - Remove `void` from the `MutationFunction`'s returned Promise types. <br/>
-  [@hwillson](https://github.com/hwillson) in [#TODO](https://github.com/apollographql/react-apollo/pull/TODO)
+  [@hwillson](https://github.com/hwillson) in [#3458](https://github.com/apollographql/react-apollo/pull/3458)
 - Documentation fixes. <br/>
   [@SeanRoberts](https://github.com/SeanRoberts) in [#3380](https://github.com/apollographql/react-apollo/pull/3380)
 

--- a/packages/common/src/types/types.ts
+++ b/packages/common/src/types/types.ts
@@ -142,7 +142,7 @@ export declare type MutationFunction<
   TVariables = OperationVariables
 > = (
   options?: MutationFunctionOptions<TData, TVariables>
-) => Promise<void | MutationFetchResult<TData>>;
+) => Promise<MutationFetchResult<TData>>;
 
 /* Subscription types */
 


### PR DESCRIPTION
The resolved value of the returned `Promise` from a `MutationFunction` cannot be `void`.

Fixes #3432.