### PR TITLE
fix: force update just after loading done with error even if the error is unchanged

### DIFF
--- a/packages/hooks/src/__tests__/useQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useQuery.test.tsx
@@ -498,6 +498,226 @@ describe('useQuery Hook', () => {
         });
       }
     );
+
+    it('should render errors (different error messages) with loading done on refetch', async () => {
+      const query = gql`
+        query SomeQuery {
+          stuff {
+            thing
+          }
+        }
+      `;
+
+      const mocks = [
+        {
+          request: { query },
+          result: {
+            errors: [new GraphQLError('an error 1')]
+          }
+        },
+        {
+          request: { query },
+          result: {
+            errors: [new GraphQLError('an error 2')]
+          }
+        }
+      ];
+
+      let renderCount = 0;
+      function App() {
+        const { loading, error, refetch } = useQuery(query, {
+          notifyOnNetworkStatusChange: true
+        });
+
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeTruthy();
+            expect(error).toBeUndefined();
+            break;
+          case 1:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: an error 1');
+            setTimeout(() => {
+              // catch here to avoid failing due to 'uncaught promise rejection'
+              refetch().catch(() => {});
+            });
+            break;
+          case 2:
+            expect(loading).toBeTruthy();
+            break;
+          case 3:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: an error 2');
+            break;
+          default: // Do nothing
+        }
+
+        renderCount += 1;
+        return null;
+      }
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <App />
+        </MockedProvider>
+      );
+
+      await wait(() => {
+        expect(renderCount).toBe(4);
+      });
+    });
+
+    it('should render errors (same error messages) with loading done on refetch', async () => {
+      const query = gql`
+        query SomeQuery {
+          stuff {
+            thing
+          }
+        }
+      `;
+
+      const mocks = [
+        {
+          request: { query },
+          result: {
+            errors: [new GraphQLError('same error message')]
+          }
+        },
+        {
+          request: { query },
+          result: {
+            errors: [new GraphQLError('same error message')]
+          }
+        }
+      ];
+
+      let renderCount = 0;
+      function App() {
+        const { loading, error, refetch } = useQuery(query, {
+          notifyOnNetworkStatusChange: true
+        });
+
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeTruthy();
+            expect(error).toBeUndefined();
+            break;
+          case 1:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: same error message');
+            setTimeout(() => {
+              // catch here to avoid failing due to 'uncaught promise rejection'
+              refetch().catch(() => {});
+            });
+            break;
+          case 2:
+            expect(loading).toBeTruthy();
+            break;
+          case 3:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: same error message');
+            break;
+          default: // Do nothing
+        }
+
+        renderCount += 1;
+        return null;
+      }
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <App />
+        </MockedProvider>
+      );
+
+      await wait(() => {
+        expect(renderCount).toBe(4);
+      });
+    });
+
+    it('should render both success and errors (same error messages) with loading done on refetch', async () => {
+      const mocks = [
+        {
+          request: { query: CAR_QUERY },
+          result: {
+            errors: [new GraphQLError('same error message')]
+          }
+        },
+        {
+          request: { query: CAR_QUERY },
+          result: {
+            data: CAR_RESULT_DATA
+          }
+        },
+        {
+          request: { query: CAR_QUERY },
+          result: {
+            errors: [new GraphQLError('same error message')]
+          }
+        }
+      ];
+
+      let renderCount = 0;
+      function App() {
+        const { loading, data, error, refetch } = useQuery(CAR_QUERY, {
+          notifyOnNetworkStatusChange: true
+        });
+
+        switch (renderCount) {
+          case 0:
+            expect(loading).toBeTruthy();
+            expect(error).toBeUndefined();
+            break;
+          case 1:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: same error message');
+            setTimeout(() => {
+              // catch here to avoid failing due to 'uncaught promise rejection'
+              refetch().catch(() => {});
+            });
+            break;
+          case 2:
+            expect(loading).toBeTruthy();
+            break;
+          case 3:
+            expect(loading).toBeFalsy();
+            expect(error).toBeUndefined();
+            expect(data).toEqual(CAR_RESULT_DATA);
+            setTimeout(() => {
+              // catch here to avoid failing due to 'uncaught promise rejection'
+              refetch().catch(() => {});
+            });
+            break;
+          case 4:
+            expect(loading).toBeTruthy();
+            break;
+          case 5:
+            expect(loading).toBeFalsy();
+            expect(error).toBeDefined();
+            expect(error!.message).toEqual('GraphQL error: same error message');
+            break;
+          default: // Do nothing
+        }
+
+        renderCount += 1;
+        return null;
+      }
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <App />
+        </MockedProvider>
+      );
+
+      await wait(() => {
+        expect(renderCount).toBe(6);
+      });
+    });
   });
 
   describe('Pagination', () => {

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -298,7 +298,12 @@ export class QueryData<TData, TVariables> extends OperationData {
       error: error => {
         this.resubscribeToQuery();
         if (!error.hasOwnProperty('graphQLErrors')) throw error;
-        if (!isEqual(error, this.previousData.error)) {
+
+        const previousResult = this.previousData.result;
+        if (
+          (previousResult && previousResult.loading) ||
+          !isEqual(error, this.previousData.error)
+        ) {
           this.previousData.error = error;
           this.forceUpdate();
         }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR will fix 'unchanging loading state' when an error, the _same_ with previous error, is occurred after `refetch` (described in #3395).  
\# *'same'* depends on `@wry/equality` implementation.

`previousData.result.loading` in `QueryData` should be `true` just before the first `error` handler called for any fetch/refetch, so this PR checks its value, and always calls `forceUpdate` if the value is `true`.  
(related PR: #3339)

After:

1. some fetch has triggered with `notifyOnNetworkStatusChange: true`
2. `loading` changes to true
3. an error occurrs for the fetch
4. `loading` changes to false and the error data can be used
5. call `refetch`
6. `loading` changes to true
7. an error occurrs for the refetch (the error message the same with the error occurred in step 3)
8. `loading` changes to false and the error data can be used (this does not occur in the previous source)

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.