### PR TITLE
Bring the `ChildDataProps` and `ChildMutateProps` types back

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@
 
 - A fix has been applied to prevent an unchanging `loading` state when an error occurs after a refetch, that is the same as the previous error. <br/>
   [@jet2jet](https://github.com/jet2jet) in [#3477](https://github.com/apollographql/react-apollo/pull/3477)
+- Add back in the removed `ChildDataProps` and `ChildMutateProps` types. <br/>
+  [@hwillson](https://github.com/hwillson) in [#3495](https://github.com/apollographql/react-apollo/pull/3495)
 
 ## 3.1.0 (2019-09-06)
 

--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -48,6 +48,8 @@ export {
   DataProps,
   MutateProps,
   ChildProps,
+  ChildDataProps,
+  ChildMutateProps,
   OptionProps,
   OperationOption,
   WithApolloClient

--- a/packages/hoc/src/types.ts
+++ b/packages/hoc/src/types.ts
@@ -63,6 +63,18 @@ export type ChildProps<
   Partial<DataProps<TData, TGraphQLVariables>> &
   Partial<MutateProps<TData, TGraphQLVariables>>;
 
+export type ChildDataProps<
+  TProps = {},
+  TData = {},
+  TGraphQLVariables = OperationVariables
+> = TProps & DataProps<TData, TGraphQLVariables>;
+
+export type ChildMutateProps<
+  TProps = {},
+  TData = {},
+  TGraphQLVariables = OperationVariables
+> = TProps & MutateProps<TData, TGraphQLVariables>;
+
 export interface OptionProps<
   TProps = any,
   TData = any,


### PR DESCRIPTION
These were accidentally removed during the 3.0 refactor.

Fixes #3421