### PR TITLE
Fix an error that the networkStatus did not change to ready at the end of pagination

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,10 @@
 
 - Make sure SSR is fully disabled when using `ssr: false` and `ssrMode: true`. <br/>
   [@maapteh](https://github.com/maapteh) in [#3515](https://github.com/apollographql/react-apollo/pull/3515)
-- Fix `MockLink`'s broken `newData` function handling.  <br/>
+- Fixed `MockLink`'s broken `newData` function handling.  <br/>
   [@pawelkleczek](https://github.com/pawelkleczek) in [#3539](https://github.com/apollographql/react-apollo/pull/3539) 
+- Fixed an issue that prevented `networkStatus` from changing `ready` at the end of pagination. <br/>
+  [@mu29](https://github.com/mu29) in [#3514](https://github.com/apollographql/react-apollo/pull/3514)
 
 ## 3.1.1 (2019-09-15)
 

--- a/packages/hooks/src/__tests__/useQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useQuery.test.tsx
@@ -842,6 +842,11 @@ describe('useQuery Hook', () => {
             case 3:
               expect(loading).toBeFalsy();
               expect(data).toEqual({
+                cars: [carResults.cars[0]]
+              });
+              break;
+            case 4:
+              expect(data).toEqual({
                 cars: [carResults.cars[0], moreCarResults.cars[0]]
               });
               break;
@@ -859,7 +864,7 @@ describe('useQuery Hook', () => {
         );
 
         await wait(() => {
-          expect(renderCount).toBe(4);
+          expect(renderCount).toBe(5);
         });
       }
     );

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -267,30 +267,14 @@ export class QueryData<TData, TVariables> extends OperationData {
       next: ({ loading, networkStatus, data }) => {
         const previousResult = this.previousData.result;
 
-        if (previousResult) {
-          // Calls to `ObservableQuery.fetchMore` return a result before the
-          // `updateQuery` function fully finishes. This can lead to an
-          // extra un-necessary re-render since the initially returned data is
-          // the same as data that has already been rendered. We'll
-          // prevent the un-necessary render from happening, making sure
-          // `fetchMore` results are only rendered when `updateQuery` has
-          // completed.
-          if (
-            previousResult.loading &&
-            previousResult.networkStatus === NetworkStatus.fetchMore &&
-            isEqual(previousResult.data, data)
-          ) {
-            return;
-          }
-
-          // Make sure we're not attempting to re-render similar results
-          if (
-            previousResult.loading === loading &&
-            previousResult.networkStatus === networkStatus &&
-            isEqual(previousResult.data, data)
-          ) {
-            return;
-          }
+        // Make sure we're not attempting to re-render similar results
+        if (
+          previousResult &&
+          previousResult.loading === loading &&
+          previousResult.networkStatus === networkStatus &&
+          isEqual(previousResult.data, data)
+        ) {
+          return;
         }
 
         this.forceUpdate();


### PR DESCRIPTION
Solves #3468

Although #3433 has improved performance by reducing the number of renders in pagination, it only works when the fetchMore function returns a new list.

If we reached to the end of the list, the fetchMore function returns the same length of result, which is determined as equal by the [@wryware/equality library](https://github.com/benjamn/wryware/blob/50e7d6181b0b937ad54b543118e823ad98e2bca9/packages/equality/src/equality.ts#L40) we currently use. Therefore, reading the last page of the list remains `networkStatus` to `NetworkStatus.fetchMore`.

I think [apollo-client](https://github.com/apollographql/apollo-client) needs to send the updated fetchMore result and the changed networkStatus at once.