### PR TITLE
Fix newData raising error per #3455 issue

### DIFF
--- a/packages/testing/src/mocks/mockLink.ts
+++ b/packages/testing/src/mocks/mockLink.ts
@@ -87,12 +87,14 @@ export class MockLink extends ApolloLink {
 
     this.mockedResponsesByKey[key].splice(responseIndex, 1);
 
-    const { result, error, delay, newData } = response;
+    const { newData } = response;
 
     if (newData) {
       response.result = newData();
       this.mockedResponsesByKey[key].push(response);
     }
+
+    const { result, error, delay } = response;
 
     if (!result && !error) {
       throw new Error(


### PR DESCRIPTION
This PR attempts to fix issue #3455 by splittting destructuring result after newData is retrieved:
```diff

-    const { result, error, delay, newData } = response;
+    const { newData } = response;

     if (newData) {
       response.result = newData();
       this.mockedResponsesByKey[key].push(response);
     }

+    const { result, error, delay } = response;
+
     if (!result && !error) {
       throw new Error(
         `Mocked response should contain either result or error: ${key}`
```