### PR TITLE
Prevent runMutation from throwing an error

### DIFF
--- a/packages/hooks/src/data/MutationData.ts
+++ b/packages/hooks/src/data/MutationData.ts
@@ -71,7 +71,6 @@ export class MutationData<
       })
       .catch((error: ApolloError) => {
         this.onMutationError(error, mutationId);
-        if (!this.getOptions().onError) throw error;
       });
   };
 


### PR DESCRIPTION
This relates to https://github.com/apollographql/apollo-client/issues/4283

`useMutation` shouldn't throw any error when it's being run. The error is already passed in the `MutationResult` object.