### PR TITLE
Add stricter options types for withQuery and withMutation

### DIFF
--- a/packages/hoc/src/mutation-hoc.tsx
+++ b/packages/hoc/src/mutation-hoc.tsx
@@ -15,7 +15,7 @@ import {
   calculateVariablesFromProps,
   GraphQLBase
 } from './hoc-utils';
-import { MutateOption, MutateOptionProps, MutateProps } from './types';
+import { OperationOption, MutateOptionProps, MutateProps } from './types';
 
 export function withMutation<
   TProps extends TGraphQLVariables | {} = {},
@@ -24,11 +24,12 @@ export function withMutation<
   TChildProps = MutateProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
-  operationOptions: MutateOption<
+  operationOptions: OperationOption<
     TProps,
     TData,
     TGraphQLVariables,
-    TChildProps
+    TChildProps,
+    MutateOptionProps<TProps, TData, TGraphQLVariables>
   > = {}
 ) {
   // this is memoized so if coming from `graphql` there is nearly no extra cost

--- a/packages/hoc/src/mutation-hoc.tsx
+++ b/packages/hoc/src/mutation-hoc.tsx
@@ -15,7 +15,7 @@ import {
   calculateVariablesFromProps,
   GraphQLBase
 } from './hoc-utils';
-import { OperationOption, OptionProps, MutateProps } from './types';
+import { MutateOption, MutateOptionProps, MutateProps } from './types';
 
 export function withMutation<
   TProps extends TGraphQLVariables | {} = {},
@@ -24,7 +24,7 @@ export function withMutation<
   TChildProps = MutateProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
-  operationOptions: OperationOption<
+  operationOptions: MutateOption<
     TProps,
     TData,
     TGraphQLVariables,
@@ -85,13 +85,13 @@ export function withMutation<
                 [resultName]: result
               } as any) as TChildProps;
               if (operationOptions.props) {
-                const newResult: OptionProps<
+                const newResult: MutateOptionProps<
                   TProps,
                   TData,
                   TGraphQLVariables
                 > = {
-                  [name]: mutate,
-                  [resultName]: result,
+                  [name as 'mutate']: mutate,
+                  [resultName as 'result']: result,
                   ownProps: props
                 };
                 childProps = operationOptions.props(newResult) as any;

--- a/packages/hoc/src/query-hoc.tsx
+++ b/packages/hoc/src/query-hoc.tsx
@@ -11,7 +11,7 @@ import {
   defaultMapPropsToOptions,
   defaultMapPropsToSkip
 } from './hoc-utils';
-import { QueryOption, QueryOptionProps, DataProps } from './types';
+import { OperationOption, QueryOptionProps, DataProps } from './types';
 
 export function withQuery<
   TProps extends TGraphQLVariables | {} = {},
@@ -20,11 +20,12 @@ export function withQuery<
   TChildProps = DataProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
-  operationOptions: QueryOption<
+  operationOptions: OperationOption<
     TProps,
     TData,
     TGraphQLVariables,
-    TChildProps
+    TChildProps,
+    QueryOptionProps<TProps, TData, TGraphQLVariables>
   > = {}
 ) {
   // this is memoized so if coming from `graphql` there is nearly no extra cost

--- a/packages/hoc/src/query-hoc.tsx
+++ b/packages/hoc/src/query-hoc.tsx
@@ -11,7 +11,7 @@ import {
   defaultMapPropsToOptions,
   defaultMapPropsToSkip
 } from './hoc-utils';
-import { OperationOption, OptionProps, DataProps } from './types';
+import { QueryOption, QueryOptionProps, DataProps } from './types';
 
 export function withQuery<
   TProps extends TGraphQLVariables | {} = {},
@@ -20,7 +20,7 @@ export function withQuery<
   TChildProps = DataProps<TData, TGraphQLVariables>
 >(
   document: DocumentNode,
-  operationOptions: OperationOption<
+  operationOptions: QueryOption<
     TProps,
     TData,
     TGraphQLVariables,
@@ -99,12 +99,12 @@ export function withQuery<
               const name = operationOptions.name || 'data';
               let childProps = { [name]: result };
               if (operationOptions.props) {
-                const newResult: OptionProps<
+                const newResult: QueryOptionProps<
                   TProps,
                   TData,
                   TGraphQLVariables
                 > = {
-                  [name]: result,
+                  [name as 'data']: result,
                   ownProps: props as TProps
                 };
                 lastResultProps = operationOptions.props(

--- a/packages/hoc/src/types.ts
+++ b/packages/hoc/src/types.ts
@@ -85,6 +85,24 @@ export interface OptionProps<
   ownProps: TProps;
 }
 
+export interface QueryOptionProps<
+  TProps = any,
+  TData = any,
+  TGraphQLVariables = OperationVariables
+>
+  extends DataProps<TData, TGraphQLVariables> {
+  ownProps: TProps;
+}
+
+export interface MutateOptionProps<
+  TProps = any,
+  TData = any,
+  TGraphQLVariables = OperationVariables
+>
+  extends MutateProps<TData, TGraphQLVariables> {
+  ownProps: TProps;
+}
+
 export interface OperationOption<
   TProps,
   TData,
@@ -109,6 +127,26 @@ export interface OperationOption<
   withRef?: boolean;
   shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean;
   alias?: string;
+}
+
+export interface QueryOption<
+  TProps,
+  TData,
+  TGraphQLVariables = OperationVariables,
+  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
+>
+  extends OperationOption<TProps, TData, TGraphQLVariables, TChildProps> {
+  props?: (props: QueryOptionProps<TProps, TData, TGraphQLVariables>, lastProps?: TChildProps | void) => TChildProps;
+}
+
+export interface MutateOption<
+  TProps,
+  TData,
+  TGraphQLVariables = OperationVariables,
+  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
+>
+  extends OperationOption<TProps, TData, TGraphQLVariables, TChildProps> {
+  props?: (props: MutateOptionProps<TProps, TData, TGraphQLVariables>, lastProps?: TChildProps | void) => TChildProps;
 }
 
 export type WithApolloClient<P> = P & { client: ApolloClient<any> };

--- a/packages/hoc/src/types.ts
+++ b/packages/hoc/src/types.ts
@@ -107,7 +107,8 @@ export interface OperationOption<
   TProps,
   TData,
   TGraphQLVariables = OperationVariables,
-  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
+  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>,
+  TOptionProps = OptionProps<TProps, TData, TGraphQLVariables>
 > {
   options?:
     | BaseQueryOptions<TGraphQLVariables>
@@ -119,7 +120,7 @@ export interface OperationOption<
         | BaseMutationOptions<TData, TGraphQLVariables>
       );
   props?: (
-    props: OptionProps<TProps, TData, TGraphQLVariables>,
+    props: TOptionProps,
     lastProps?: TChildProps | void
   ) => TChildProps;
   skip?: boolean | ((props: TProps) => boolean);
@@ -127,26 +128,6 @@ export interface OperationOption<
   withRef?: boolean;
   shouldResubscribe?: (props: TProps, nextProps: TProps) => boolean;
   alias?: string;
-}
-
-export interface QueryOption<
-  TProps,
-  TData,
-  TGraphQLVariables = OperationVariables,
-  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
->
-  extends OperationOption<TProps, TData, TGraphQLVariables, TChildProps> {
-  props?: (props: QueryOptionProps<TProps, TData, TGraphQLVariables>, lastProps?: TChildProps | void) => TChildProps;
-}
-
-export interface MutateOption<
-  TProps,
-  TData,
-  TGraphQLVariables = OperationVariables,
-  TChildProps = ChildProps<TProps, TData, TGraphQLVariables>
->
-  extends OperationOption<TProps, TData, TGraphQLVariables, TChildProps> {
-  props?: (props: MutateOptionProps<TProps, TData, TGraphQLVariables>, lastProps?: TChildProps | void) => TChildProps;
 }
 
 export type WithApolloClient<P> = P & { client: ApolloClient<any> };


### PR DESCRIPTION
This builds upon #2573 and adds stricter typings for the parameter passed to the `props` option when using the more specific HOC exports `withQuery` and `withMutation`. As an example:

```ts
withQuery<PublicProps, QueryType>(doc, {
  // props param used to be typed as OptionProps, the optional'd combination of QueryProps
  // and MutateProps, will now be the specific type corresponding to the HOC used
  props: (props) => ({
    computeUsefulThing: () => {
      // according to typescript:
      props.data // may or may not be defined (this is a query, so it's always defined)
      props.mutate // may or may not be defined (in reality it's never defined)
    }
  })
});
```

### Checklist:

* [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

