### PR TITLE
Add missing client property to useLazyQuery Result object.

### DIFF
--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -69,7 +69,8 @@ export class QueryData<TData, TVariables> extends OperationData {
             loading: false,
             networkStatus: NetworkStatus.ready,
             called: false,
-            data: undefined
+            data: undefined,
+            client: this.client
           } as QueryResult<TData, TVariables>
         ]
       : [this.runLazyQuery, this.execute()];


### PR DESCRIPTION
From [the documentation](https://www.apollographql.com/docs/react/api/react-hooks/#result-1) the result object returned by `useLazyQuery` should contains the `client` property.

## Side note
In this point of code there is an unsafe casting which prevent to spot the error using the type system.
Probably other properties are missing.