### PR TITLE
Ensure updateQuery is included in QueryResult with useLazyQuery

### DIFF
--- a/packages/hooks/src/__tests__/useLazyQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useLazyQuery.test.tsx
@@ -447,4 +447,65 @@ describe('useLazyQuery Hook', () => {
       expect(renderCount).toBe(5);
     });
   });
+
+  it('should pass updateQuery in QueryResult', async () => {
+    const data1 = CAR_RESULT_DATA;
+    const data2 = {
+      cars: []
+    };
+    const mocks = [
+      {
+        request: {
+          query: CAR_QUERY
+        },
+        result: { data: data1 }
+      }
+    ];
+
+    let renderCount = 0;
+    const Component = () => {
+      const [execute, { loading, data, updateQuery }] = useLazyQuery(
+        CAR_QUERY,
+        {
+          fetchPolicy: 'network-only'
+        }
+      );
+      switch (renderCount) {
+        case 0:
+          expect(updateQuery).toBeDefined();
+          expect(loading).toEqual(false);
+          setTimeout(() => {
+            execute();
+          });
+          break;
+        case 1:
+          expect(loading).toEqual(true);
+          break;
+        case 2:
+          expect(loading).toEqual(false);
+          expect(data).toEqual(data1);
+          setTimeout(() => {
+            updateQuery(() => data2);
+          });
+          break;
+        case 3:
+          expect(loading).toEqual(false);
+          expect(data).toEqual(data2);
+          break;
+        default: // Do nothing
+      }
+      renderCount += 1;
+      return null;
+    };
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <Component />
+      </MockedProvider>
+    );
+
+    await wait(() => {
+      expect(renderCount).toBe(4);
+    });
+  });
 });

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -14,6 +14,7 @@ import {
   QueryResult,
   ObservableQueryFields
 } from '@apollo/react-common';
+import { invariant } from 'ts-invariant';
 
 import {
   QueryPreviousData,
@@ -69,7 +70,8 @@ export class QueryData<TData, TVariables> extends OperationData {
             loading: false,
             networkStatus: NetworkStatus.ready,
             called: false,
-            data: undefined
+            data: undefined,
+            updateQuery: this.lazyUpdateQuery
           } as QueryResult<TData, TVariables>
         ]
       : [this.runLazyQuery, this.execute()];
@@ -487,4 +489,16 @@ export class QueryData<TData, TVariables> extends OperationData {
       subscribeToMore: this.obsSubscribeToMore
     } as ObservableQueryFields<TData, TVariables>;
   }
+
+  private lazyUpdateQuery: QueryResult<
+    TData,
+    TVariables
+  >['updateQuery'] = mapFn => {
+    const { query } = this.currentObservable;
+    invariant(
+      query,
+      `updateQuery cannot be invoked if the lazy query was not executed first.`
+    );
+    return query!.updateQuery(mapFn);
+  };
 }


### PR DESCRIPTION
From [the documentation](https://www.apollographql.com/docs/react/api/react-hooks/#result-1) the result object returned by `useLazyQuery` should contains the `updateQuery` property.

## Side note
In this point of code there is an unsafe casting which prevent to spot the error using the type system.
Probably other properties are missing.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

