### PR TITLE
fix: add check for resetQueryStoreErrors in afterExecute

### DIFF
--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -64,14 +64,14 @@ export class QueryData<TData, TVariables> extends OperationData {
   public executeLazy(): QueryTuple<TData, TVariables> {
     return !this.runLazy
       ? [
-          this.runLazyQuery,
-          {
-            loading: false,
-            networkStatus: NetworkStatus.ready,
-            called: false,
-            data: undefined
-          } as QueryResult<TData, TVariables>
-        ]
+        this.runLazyQuery,
+        {
+          loading: false,
+          networkStatus: NetworkStatus.ready,
+          called: false,
+          data: undefined
+        } as QueryResult<TData, TVariables>
+      ]
       : [this.runLazyQuery, this.execute()];
   }
 
@@ -98,6 +98,7 @@ export class QueryData<TData, TVariables> extends OperationData {
       // requests/responses.
       setTimeout(() => {
         this.currentObservable.query &&
+          this.currentObservable.query.resetQueryStoreErrors &&
           this.currentObservable.query.resetQueryStoreErrors();
       });
     }
@@ -257,7 +258,7 @@ export class QueryData<TData, TVariables> extends OperationData {
         // need to log it here. We could conceivably log something if
         // an option was set. OTOH we don't log errors w/ the original
         // query. See https://github.com/apollostack/react-apollo/issues/404
-        .catch(() => {});
+        .catch(() => { });
     }
   }
 
@@ -358,9 +359,9 @@ export class QueryData<TData, TVariables> extends OperationData {
         result.data =
           previousData && data
             ? {
-                ...previousData,
-                ...data
-              }
+              ...previousData,
+              ...data
+            }
             : previousData || data;
       } else if (error) {
         Object.assign(result, {


### PR DESCRIPTION
Add a check for resetQueryStoreErrors.

In theory the resetQueryStoreErrors function is in query's prototype, it should not be undefined, but we encountered a case where resetQueryStoreErrors is undefined after some network error.
So got an error like:
```
TypeError: t.currentObservable.query.resetQueryStoreErrors is not a function
```

Still chasing what caused it.
As a quick fix, just added a check for resetQueryStoreErrors.

Please close this pull request, if not related.
Thanks.
And thanks for your time in advance.

### Checklist:

* [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

