### PR TITLE
Allow to set FetchResult generic type in MockedResponse

### DIFF
--- a/packages/testing/src/mocks/types.ts
+++ b/packages/testing/src/mocks/types.ts
@@ -5,12 +5,12 @@ import { ApolloLink } from 'apollo-link';
 
 export type ResultFunction<T> = () => T;
 
-export interface MockedResponse {
+export interface MockedResponse<TData = any> {
   request: GraphQLRequest;
-  result?: FetchResult | ResultFunction<FetchResult>;
+  result?: FetchResult<TData> | ResultFunction<FetchResult<TData>>;
   error?: Error;
   delay?: number;
-  newData?: ResultFunction<FetchResult>;
+  newData?: ResultFunction<FetchResult<TData>>;
 }
 
 export interface MockedSubscriptionResult {


### PR DESCRIPTION
Currently there is no way to specify the shape of the `FetchResult` of a `MockedResponse`. Because of this, it's easy to pass the incorrect `data` to `MockedResponse`. By adding the `TData` generic to `FetchResult` it's possible to specify the shape of data that the query should return.

```
interface Result {
  someMutation: {
    ok: boolean
  }
}

const mockedResponse: MockedResponse<Result> = {
  request: {
    query: SomeDocument
  },
  data: {
    someMutation: {
       ok: true // This is now typechecked
       something: '', // TS error because this does not exist in `Result` type.
    }
  }
}
```