### PR TITLE
[RFC] Allow startPolling without having to exec first

### DIFF
--- a/packages/hooks/src/__tests__/useLazyQuery.test.tsx
+++ b/packages/hooks/src/__tests__/useLazyQuery.test.tsx
@@ -389,4 +389,43 @@ describe('useLazyQuery Hook', () => {
       });
     }
   );
+
+  it('should support polling programatically', done => {
+    let renderCount = 0;
+    const Component = () => {
+      let [_, { data, loading, startPolling, stopPolling }] = useLazyQuery(
+        CAR_QUERY
+      );
+      switch (renderCount) {
+        case 0:
+          expect(loading).toBeFalsy();
+          startPolling(10);
+          break;
+        case 1:
+          expect(loading).toBeTruthy();
+          break;
+        case 2:
+          expect(loading).toBeFalsy();
+          expect(data).toEqual(CAR_RESULT_DATA);
+          stopPolling();
+          setTimeout(() => {
+            done();
+          }, 10);
+          break;
+        case 3:
+          done.fail('Uh oh - we should have stopped polling!');
+          break;
+        default:
+        // Do nothing
+      }
+      renderCount += 1;
+      return null;
+    };
+
+    render(
+      <MockedProvider mocks={CAR_MOCKS}>
+        <Component />
+      </MockedProvider>
+    );
+  });
 });

--- a/packages/hooks/src/data/QueryData.ts
+++ b/packages/hooks/src/data/QueryData.ts
@@ -69,7 +69,14 @@ export class QueryData<TData, TVariables> extends OperationData {
             loading: false,
             networkStatus: NetworkStatus.ready,
             called: false,
-            data: undefined
+            data: undefined,
+            startPolling: (pollInterval: number) => {
+              this.setOptions({
+                ...super.getOptions(),
+                pollInterval
+              });
+              this.runLazyQuery();
+            }
           } as QueryResult<TData, TVariables>
         ]
       : [this.runLazyQuery, this.execute()];


### PR DESCRIPTION
### Checklist:
* [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [x] Make sure all of the significant new logic is covered by tests
* [x] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

Related to https://github.com/apollographql/apollo-client/issues/5140

When using `useLazyQuery`, the return value does not include `ObservableQueryFields`, hence you cannot call `startPolling` until after you call `runLazyQuery` which is inconvenient.

At the very least the type of the return value of `useLazyQuery` should be modified to indicate that `ObservableQueryFields` maybe undefined.