### PR TITLE
Adds missing dependency

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@apollo/react-common": "file:../common",
     "@wry/equality": "^0.1.9",
+    "apollo-utilities": "^1.3.2",
     "ts-invariant": "^0.4.4",
     "tslib": "^1.10.0"
   },


### PR DESCRIPTION
`@apollo/react-hooks` has an unmet peer dependency on `apollo-utilities` through `@apollo/react-common`. This diff fixes that (which otherwise cause `react-apollo` to fail strictness checks in modern package managers).