### PR TITLE
Adds missing peer dependencies to ssr

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -36,12 +36,16 @@
     "test:umd": "npm run build && npx jest --config ../../config/jest.umd.config.js --testPathPattern packages/ssr"
   },
   "peerDependencies": {
+    "apollo-client": "^2.6.4",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
   "dependencies": {
     "@apollo/react-common": "file:../common",
     "@apollo/react-hooks": "file:../hooks",
+    "@types/react": "^16.8.0",
+    "apollo-utilities": "^1.3.2",
+    "graphql": "^14.3.1",
     "tslib": "^1.10.0"
   },
   "files": [


### PR DESCRIPTION
`@apollo/react-ssr` has an unmet peer dependency on various packages through `@apollo/react-common` and `@apollo/react-hooks`. This diff fixes that (which otherwise cause `react-ssr` to fail strictness checks in modern package managers).

As long as you're here, can you please give a look to the following related PRs? 😃
- [`apollo-engine-reporting`](https://github.com/apollographql/apollo-server/pull/3496)
- [`apollo-link-error`](https://github.com/apollographql/apollo-link/pull/1196)
- [`apollo-cache`](https://github.com/apollographql/apollo-client/pull/5081#issuecomment-552485218)
- [`@apollo/react-hooks`](https://github.com/apollographql/react-apollo/pull/3680)