### PR TITLE
feat: Added helping generic types for hooks

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -5,10 +5,10 @@ export {
   resetApolloContext
 } from '@apollo/react-common';
 
-export { useQuery } from './useQuery';
-export { useLazyQuery } from './useLazyQuery';
-export { useMutation } from './useMutation';
-export { useSubscription } from './useSubscription';
+export * from './useQuery';
+export * from './useLazyQuery';
+export * from './useMutation';
+export * from './useSubscription';
 export { useApolloClient } from './useApolloClient';
 
 export { RenderPromises } from './ssr/RenderPromises';

--- a/packages/hooks/src/useLazyQuery.ts
+++ b/packages/hooks/src/useLazyQuery.ts
@@ -4,6 +4,11 @@ import { DocumentNode } from 'graphql';
 import { LazyQueryHookOptions, QueryTuple } from './types';
 import { useBaseQuery } from './utils/useBaseQuery';
 
+export type UseLazyQuery<TData = any, TVariables = OperationVariables> = (
+  query: DocumentNode,
+  options?: LazyQueryHookOptions<TData, TVariables>
+) => QueryTuple<TData, TVariables>;
+
 export function useLazyQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: LazyQueryHookOptions<TData, TVariables>

--- a/packages/hooks/src/useMutation.ts
+++ b/packages/hooks/src/useMutation.ts
@@ -5,6 +5,11 @@ import { DocumentNode } from 'graphql';
 import { MutationHookOptions, MutationTuple } from './types';
 import { MutationData } from './data/MutationData';
 
+export type UseMutation<TData = any, TVariables = OperationVariables> = (
+  query: DocumentNode,
+  options?: MutationHookOptions<TData, TVariables>
+) => MutationTuple<TData, TVariables>;
+
 export function useMutation<TData = any, TVariables = OperationVariables>(
   mutation: DocumentNode,
   options?: MutationHookOptions<TData, TVariables>

--- a/packages/hooks/src/useQuery.ts
+++ b/packages/hooks/src/useQuery.ts
@@ -4,6 +4,11 @@ import { DocumentNode } from 'graphql';
 import { QueryHookOptions } from './types';
 import { useBaseQuery } from './utils/useBaseQuery';
 
+export type UseQuery<TData = any, TVariables = OperationVariables> = (
+  query: DocumentNode,
+  options?: QueryHookOptions<TData, TVariables>
+) => QueryResult<TData, TVariables>;
+
 export function useQuery<TData = any, TVariables = OperationVariables>(
   query: DocumentNode,
   options?: QueryHookOptions<TData, TVariables>

--- a/packages/hooks/src/useSubscription.ts
+++ b/packages/hooks/src/useSubscription.ts
@@ -1,9 +1,20 @@
 import { useContext, useState, useRef, useEffect } from 'react';
 import { DocumentNode } from 'graphql';
+import { ApolloError } from 'apollo-client';
 import { getApolloContext, OperationVariables } from '@apollo/react-common';
 
 import { SubscriptionHookOptions } from './types';
 import { SubscriptionData } from './data/SubscriptionData';
+
+export type UseSubscription<TData = any, TVariables = OperationVariables> = (
+  query: DocumentNode,
+  options?: SubscriptionHookOptions<TData, TVariables>
+) => {
+  variables: TVariables;
+  loading: boolean;
+  data?: TData;
+  error?: ApolloError;
+};
 
 export function useSubscription<TData = any, TVariables = OperationVariables>(
   subscription: DocumentNode,


### PR DESCRIPTION
When using TypeScript and code generation tools for GraphQL query typings, the use of hooks such as `useQuery` can become very bloated with long generics, and what should probably a simple one liner gets quite hard to read, specially with multiple hooks (many mutations, for instance).

**No TypeScript:**

```jsx
import { useQuery } from '@apollo/react-hooks'

const HelloWorld = ({ name }) => {
  const { data, loading } = useQuery(HELLO_WORLD_QUERY, { variables: { name } })

  return loading ? 'loading' : <p>{data.hello}</p>
}
```

**Typescript:**

```tsx
import { useQuery } from '@apollo/react-hooks'

import {
  HELLO_WORLD_QUERY_DATA,
  HELLO_WORLD_QUERY_VARIABLES,
} from './generated-types'

const HelloWorld: React.FC<{ name: string }> = ({ name }) => {
  const { data, loading } = useQuery<
    HELLO_WORLD_QUERY_DATA,
    HELLO_WORLD_QUERY_VARIABLES
  >(HELLO_WORLD_QUERY, { variables: { name } })

  return loading ? 'loading' : <p>{data.hello}</p>
}
```

What this pull-request does is export a generic type to allow typing of queries/mutations before we use hooks. Outcome could be something like this:

**TypeScript with UseQuery/UseMutation/UseSubscription:**

```tsx
import { useQuery, UseQuery } from '@apollo/react-hooks'

import {
  HELLO_WORLD_QUERY_DATA,
  HELLO_WORLD_QUERY_VARIABLES,
} from './generated-types'

const useHelloWorld: UseQuery<
  HELLO_WORLD_QUERY_DATA,
  HELLO_WORLD_QUERY_VARIABLES
> = useQuery

const HelloWorld: React.FC<{ name: string }> = ({ name }) => {
  const { data, loading } = useHelloWorld(HELLO_WORLD_QUERY, { variables: { name } })

  return loading ? 'loading' : <p>{data.hello}</p>
}
```

As can be seen, this makes it easier to reduce complexity and code within the component itself, while moving static non-variable procedures such as typing outside the business code.

> **Ps.:** some may say this is already possible by creating a secondary hook, which is a similar solution, but the solution with helper types guarantees we have same APIs available with no need to create new interfaces due to custom hooks argument types.