### PR TITLE
Remove react-dom peer dep from react-apollo/hooks

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -39,8 +39,7 @@
     "@types/react": "^16.8.0",
     "apollo-client": "^2.6.4",
     "graphql": "^14.3.1",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0"
   },
   "dependencies": {
     "@apollo/react-common": "file:../common",


### PR DESCRIPTION
Fixes #3704 

Looked through all the files for this package and I didn't see any usage of `react-dom` so its unnecessary as a peer dep. I didn't check other packages, so its possible the peer dep is extraneous elsewhere as well.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

