### PR TITLE
Test use case where you have resolvers for some data, but not all of it

### DIFF
--- a/packages/hoc/src/__tests__/MockedProvider.test.tsx
+++ b/packages/hoc/src/__tests__/MockedProvider.test.tsx
@@ -630,7 +630,16 @@ describe('@client testing', () => {
       const ContainerWithData = withNetworkStatus(Container);
 
       render(
-        <MockedProvider mocks={networkStatusMocks}>
+        <MockedProvider
+          mocks={networkStatusMocks}
+          resolvers={{
+            Query: {
+              foo() {
+                return null;
+              }
+            }
+          }}
+        >
           <ContainerWithData />
         </MockedProvider>
       );


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [X] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

@hwillson @benjamn I found an issue with apollo client.

essentially if you have `resolvers` for apollo local state, but you don't specify resolvers for *ALL* of your local data, the Client doesn't do what you would expect.

this simple change in a test doesn't do a full test case of this functionality but from a high level this is what you would expect:


you might have the client data:

``` typescript
interface LocalState {
  todos: {title: string, done: boolean}[];
  visibilityFilter: 'NEW' | 'ALL' | 'DONE';
}
```

and you might have a localState resolver for the `todos` but maybe not for the `visibilityFilter` because it's rather simple. in this case, ApolloClient will not resolve the visibilityFilter data as you would expect.