### PR TITLE
Remove un-needed peerDependency.

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,6 @@
   "peerDependencies": {
     "@types/react": "^16.8.0",
     "apollo-client": "^2.6.4",
-    "apollo-utilities": "^1.3.2",
     "graphql": "^14.3.1",
     "react": "^16.8.0"
   },


### PR DESCRIPTION
apollo-utilities isn't used in this project, causes unecessary warnings.

Removed in v4 alphas I know but that's not a stable release yet and would like to get rid of this warning for 3.x branch without having to wait until whenever 4 stable is released.

<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

* [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] If this was a change that affects the external API used in GitHunt-React, update GitHunt-React and post a link to the PR in the discussion.

